### PR TITLE
provides for shared link to sitemap.xml.gz 

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -24,7 +24,7 @@ set :log_level, :info
 # set :pty, true
 
 # Default value for :linked_files is []
-set :linked_files, %w{config/database.yml config/secrets.yml config/solr.yml public/robots.txt}
+set :linked_files, %w{config/database.yml config/secrets.yml config/solr.yml public/robots.txt public/sitemap.xml.gz}
 
 # Default value for linked_dirs is []
 set :linked_dirs, %w{bin config/settings log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}


### PR DESCRIPTION
I have a tool in the robot suite to generate the sitemap from all the slugs in the Solr index. See https://github.com/sul-dlss/gis-robot-suite/blob/master/tools/generate_sitemap.rb. I've uploaded the sitemaps to -prod in the `shared/public` folder.

Also see https://github.com/geoblacklight/geoblacklight/issues/14
