### PR TITLE
add default from address to enable email features

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,4 +75,8 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+  
+  config.action_mailer.default_options = {
+    :from => 'no-reply@earthworks.stanford.edu'
+  }
 end


### PR DESCRIPTION
My change in production got overwritten in the next production push. I didn't realize that `config/environments` wasn't under `shared` as it is in other systems. so, I added the mailer defaults to git.
