### PR TITLE
use alert class danger (error deprecated in bootstrap)

### DIFF
--- a/app/controllers/feedback_forms_controller.rb
+++ b/app/controllers/feedback_forms_controller.rb
@@ -40,7 +40,7 @@ class FeedbackFormsController < ApplicationController
       params[:viewport]   =~ url_regex
       errors << 'Your message appears to be spam, and has not been sent.'
     end
-    flash[:error] = errors.join('<br/>') unless errors.empty?
-    flash[:error].nil?
+    flash[:danger] = errors.join('<br/>') unless errors.empty?
+    flash[:danger].nil?
   end
 end

--- a/spec/controllers/feedback_forms_controller_spec.rb
+++ b/spec/controllers/feedback_forms_controller_spec.rb
@@ -22,43 +22,43 @@ describe FeedbackFormsController do
            url: 'http://test.host/',
            message: '',
            email_address: ''
-      expect(flash[:error]).to eq 'A message is required'
+      expect(flash[:danger]).to eq 'A message is required'
     end
     it 'should block potential spam with a href in the message' do
       post :create,
            message: 'I like to spam by sending you a http://www.somespam.com.  lolzzzz',
            url: 'http://test.host/',
            email_address: ''
-      expect(flash[:error]).to eq 'Your message appears to be spam, and has not been sent. Please try sending your message again without any links in the comments.'
+      expect(flash[:danger]).to eq 'Your message appears to be spam, and has not been sent. Please try sending your message again without any links in the comments.'
     end
     it 'should block potential spam with a url= in the message' do
       post :create,
            message: 'I like to spam by sending you a http://www.somespam.com.  lolzzzz',
            url: 'http://test.host/',
            email_address: ''
-      expect(flash[:error]).to eq 'Your message appears to be spam, and has not been sent. Please try sending your message again without any links in the comments.'
+      expect(flash[:danger]).to eq 'Your message appears to be spam, and has not been sent. Please try sending your message again without any links in the comments.'
     end
     it 'should block potential spam with a http:// in the message' do
       post :create,
            message: 'I like to spam by sending you a http://www.somespam.com.  lolzzzz',
            url: 'http://test.host/',
            email_address: ''
-      expect(flash[:error]).to eq 'Your message appears to be spam, and has not been sent. Please try sending your message again without any links in the comments.'
+      expect(flash[:danger]).to eq 'Your message appears to be spam, and has not been sent. Please try sending your message again without any links in the comments.'
     end
     it 'should block potential spam with a http:// in the user_agent field' do
       post :create, user_agent: 'http://www.google.com', message: 'Legit message', url: 'http://test.host'
-      expect(flash[:error]).to eq 'Your message appears to be spam, and has not been sent.'
+      expect(flash[:danger]).to eq 'Your message appears to be spam, and has not been sent.'
     end
     it 'should block potential spam with a http:// in the viewport field' do
       post :create, viewport: 'http://www.google.com', message: 'Legit message', url: 'http://test.host'
-      expect(flash[:error]).to eq 'Your message appears to be spam, and has not been sent.'
+      expect(flash[:danger]).to eq 'Your message appears to be spam, and has not been sent.'
     end
     it 'should return an error if a bot fills in the email_addrss field (email is correct field)' do
       post :create,
            message: 'I am spamming you!',
            url: 'http://test.host/',
            email_address: 'spam!'
-      expect(flash[:error]).to eq 'You have filled in a field that makes you appear as a spammer.  Please follow the directions for the individual form fields.'
+      expect(flash[:danger]).to eq 'You have filled in a field that makes you appear as a spammer.  Please follow the directions for the individual form fields.'
     end
   end
 end


### PR DESCRIPTION
Was using a deprecated class that didn't correctly show the warning message.

Thanks @ggeisler !!
