### PR TITLE
fix login/logout to redirect back to current page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,4 +13,14 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  # to use the login/logout features, add a :referrer parameter to your URL
+  def devise_referrer_path
+    params[:referrer] || root_path
+  end
+  
+  # override devise function for determining where to go after logout
+  def after_sign_out_path_for(resource_or_scope)
+    devise_referrer_path
+  end
 end

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -1,7 +1,5 @@
 class LoginController < ApplicationController
-
   def login
-    redirect_to params[:referrer] || :back
+    redirect_to devise_referrer_path
   end
-
 end

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -22,7 +22,7 @@
   <ul class="nav navbar-nav">
     <% if current_user %>
     <li>
-      <%= link_to t('blacklight.header_links.logout'), destroy_user_session_path %>
+      <%= link_to t('blacklight.header_links.logout'), destroy_user_session_path(referrer: request.original_url) %>
     </li>
     <% unless current_user.to_s.blank? -%>
     <li>
@@ -31,7 +31,7 @@
     <% end %>
     <% else %>
     <li>
-      <%= link_to t('blacklight.header_links.login'), new_user_session_path %>
+      <%= link_to t('blacklight.header_links.login'), new_user_session_path(referrer: request.original_url) %>
     </li>
     <% end %>
   </ul>


### PR DESCRIPTION
Works for both login links and logout links. Will take the user back to the current page during a WebAuth sign in or sign out.

fixes #99 
