### PR TITLE
adds in message if no downloads are available

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,8 @@
 module ApplicationHelper
+  def document_unavailable_options(document)
+    options = []
+    options.push 'download' unless document.direct_download || document.download_types.present?
+    options.push('preview', 'download') unless document_available? || document.stanford? || document.restricted?
+    options
+  end
 end

--- a/app/views/catalog/_show_message.html.erb
+++ b/app/views/catalog/_show_message.html.erb
@@ -1,10 +1,11 @@
 <% document ||= @document %>
+<% document_unavailable = document_unavailable_options(document).uniq %>
 
-<% unless (document_available? || document.stanford? || document.restricted?) %>
+<% if document_unavailable.any? %>
   <div class='alert alert-warning unavailable-warning'>
-    <i class='fa fa-exclamation-triangle'></i>This data is hosted by <strong><%= document[:dct_provenance_s] %></strong>, and is currently unavailable to view or download. If you have questions about this or other unavailable datasets please submit this as 
+    <i class='fa fa-exclamation-triangle'></i>This data is hosted by <strong><%= document[:dct_provenance_s] %></strong>, and is currently unavailable to <%= document_unavailable.to_sentence %>. If you have questions about this or other unavailable datasets please submit this as 
     <%= link_to feedback_path, data: { toggle: 'collapse', target: '#feedback-form' } do %>
-    feedback
+      feedback
     <% end %>.
   </div>
 <% end %>

--- a/spec/features/unavailable_layer_spec.rb
+++ b/spec/features/unavailable_layer_spec.rb
@@ -1,11 +1,19 @@
 require 'rails_helper'
 
 feature 'Unavailable layer' do
-  scenario 'hides and shows appropriate messages' do
+  scenario 'hides and shows appropriate messages for geomonitored unavailable' do
     visit catalog_path 'harvard-ntadcd106'
     within '.unavailable-warning' do
       expect(page).to have_content 'Harvard'
+      expect(page).to have_content 'unavailable to preview and download'
     end
     expect(page).to_not have_content 'Download Shapefile'
+  end
+  scenario 'with no downloads shows no download message' do
+    visit catalog_path 'princeton-02870w62c'
+    within '.unavailable-warning' do
+      expect(page).to have_content 'Princeton'
+      expect(page).to have_content 'unavailable to download'
+    end
   end
 end


### PR DESCRIPTION
Addresses concerns raised in ad hoc meeting about letting the user know that a layer is unavailable to download if no download options are present.

Deployed to dev successfully 

Closes #188 