### PR TITLE
Add saved search button to search results page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,8 @@ group :development, :test do
   gem 'rspec-rails', '~> 3.1.0'
   gem 'capybara'
   gem 'poltergeist'
+  gem 'factory_girl_rails'
+  gem 'database_cleaner'
 end
 
 gem 'coveralls', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,7 @@ GEM
       simplecov (~> 0.9.1)
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
+    database_cleaner (1.4.0)
     deprecation (0.2.1)
       activesupport
     devise (3.4.1)
@@ -121,6 +122,11 @@ GEM
     docile (1.1.5)
     erubis (2.7.0)
     execjs (2.3.0)
+    factory_girl (4.5.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.5.0)
+      factory_girl (~> 4.5.0)
+      railties (>= 3.0.0)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.6)
@@ -314,10 +320,12 @@ DEPENDENCIES
   capybara
   coffee-rails (~> 4.0.0)
   coveralls
+  database_cleaner
   devise
   devise-guests (~> 0.3.3)
   devise-remote-user
   geoblacklight (~> 0.7.1)
+  factory_girl_rails
   is_it_working
   jbuilder (~> 2.0)
   jettywrapper

--- a/app/assets/stylesheets/earthworks.css.scss
+++ b/app/assets/stylesheets/earthworks.css.scss
@@ -5,6 +5,7 @@
 @import 'modules/header_navbar';
 @import 'modules/home';
 @import 'modules/leaflet';
+@import 'modules/results';
 @import 'modules/show';
 @import 'modules/sul_footer';
 @import 'modules/top_navbar';

--- a/app/assets/stylesheets/modules/results.scss
+++ b/app/assets/stylesheets/modules/results.scss
@@ -1,0 +1,6 @@
+.search-widgets {
+  form.button_to {
+    display: inline;
+    position: relative;
+  }
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -232,6 +232,9 @@ class CatalogController < ApplicationController
     config.add_show_tools_partial :downloads, partial: 'downloads', if: proc { |_context, _config, options| options[:document] }
     config.show.document_actions.delete(:sms)
     config.show.document_actions.delete(:citation)
+
+    # Custom results collection tool for GeoBlacklight
+    config.add_results_collection_tool :save_search
   end
 
 

--- a/app/views/catalog/_save_search.html.erb
+++ b/app/views/catalog/_save_search.html.erb
@@ -1,0 +1,8 @@
+<% search ||= @current_search_session %>
+<% if search %>
+  <% if current_or_guest_user && search.saved? %>
+    <%= button_to t('blacklight.search_history.forget'), forget_search_path(search.id), :class => 'btn btn-default' %>
+  <% else %>
+    <%= button_to t('blacklight.search_history.save'), save_search_path(search.id), :method => :put, :class => 'btn btn-default' %>
+  <% end %>
+<% end %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -9,3 +9,6 @@ en:
       show:
         title_html: '%{document_title} in %{application_name}'
         label: '%{label}'
+    search_history:
+      save: 'Save this search'
+      forget: 'Forget this search'

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :user do
+    sequence(:email) { |n| "user#{n}@example.com" }
+    password 'insecure'
+  end
+end

--- a/spec/features/saved_searches_spec.rb
+++ b/spec/features/saved_searches_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+feature 'Saved searches' do
+  let(:user) { FactoryGirl.create(:user) }
+  before { login_as user }
+  scenario 'test' do
+    visit catalog_index_path q: '*'
+    click_button 'Save this search'
+    visit saved_searches_path
+    expect(page).to have_css 'td', count: 2 #Saved searches are stored in a table
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,9 @@ require 'coveralls'
 
 Coveralls.wear!('rails')
 
+require 'devise'
+require 'factory_girl'
+
 Capybara.register_driver :poltergeist do |app|
   Capybara::Poltergeist::Driver.new(app, timeout: 60)
 end
@@ -43,6 +46,21 @@ RSpec.configure do |config|
   # examples within a transaction, remove the following line or assign false
   # instead of true.
   config.use_transactional_fixtures = true
+
+  config.before(:suite) do
+    begin
+      DatabaseCleaner.start
+      FactoryGirl.lint
+    ensure
+      DatabaseCleaner.clean
+    end
+  end
+
+  config.include Devise::TestHelpers, type: :controller
+  config.include Devise::TestHelpers, type: :view
+  config.include Warden::Test::Helpers, type: :feature
+
+  config.include FactoryGirl::Syntax::Methods
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and


### PR DESCRIPTION
Previously, it was quite difficult to actually find how to save searches. This is now easier as "Save this search" and "Forget this search" are in the results tools

![screen shot 2015-03-04 at 3 16 51 pm](https://cloud.githubusercontent.com/assets/1656824/6495722/946400b4-c281-11e4-8030-748e1b4435cc.png)
![screen shot 2015-03-04 at 3 16 46 pm](https://cloud.githubusercontent.com/assets/1656824/6495723/9464678e-c281-11e4-840f-83595c1ef342.png)
