### PR TITLE
re-enable squash notify

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -23,7 +23,7 @@ require 'capistrano/rvm'
 require 'capistrano/bundler'
 require 'capistrano/rails/assets'
 require 'dlss/capistrano'
-# require 'squash/rails/capistrano3'
+require 'squash/rails/capistrano3'
 require 'capistrano/sitemap_generator'
 
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,8 @@ end
 gem 'coveralls', require: false
 
 group :deployment do
-  gem 'capistrano', '3.2.1'
+  # pin to 3.4.0 for upgrade compatibility reasons
+  gem 'capistrano', '3.4.0'
   gem 'capistrano-rvm'
   gem 'capistrano-bundler'
   gem 'capistrano-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ GEM
     bundler-audit (0.3.1)
       bundler (~> 1.2)
       thor (~> 0.18)
-    capistrano (3.2.1)
+    capistrano (3.4.0)
       i18n
       rake (>= 10.0.0)
       sshkit (~> 1.3)
@@ -281,7 +281,7 @@ GEM
       squash_ruby
     squash_ruby (2.0.0)
       json
-    sshkit (1.6.1)
+    sshkit (1.7.1)
       colorize (>= 0.7.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
@@ -314,7 +314,7 @@ PLATFORMS
 
 DEPENDENCIES
   blacklight (~> 5.9.3)
-  capistrano (= 3.2.1)
+  capistrano (= 3.4.0)
   capistrano-bundler
   capistrano-rails
   capistrano-rvm

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
-# config valid only for Capistrano 3.1
-lock '3.2.1'
+# config valid only for Capistrano 3.4.0
+lock '3.4.0'
 
 set :application, 'earthworks'
 set :repo_url, 'https://github.com/sul-dlss/earthworks.git'
@@ -27,7 +27,7 @@ set :log_level, :info
 set :linked_files, %w{config/database.yml config/secrets.yml config/solr.yml public/robots.txt}
 
 # Default value for linked_dirs is []
-set :linked_dirs, %w{bin config/settings log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system public/sitemaps}
+set :linked_dirs, %w{config/settings log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system public/sitemaps}
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }
@@ -58,4 +58,4 @@ namespace :deploy do
 
 end
 
-# before 'deploy:publishing', 'squash:write_revision'
+before 'deploy:publishing', 'squash:write_revision'


### PR DESCRIPTION
Re enables squash notify for EarthWorks. This was disabled because of an issue with the inclusion of the  `bin` directory as a linked_dir. 

See: https://github.com/kirs/capistrano/commit/e4f3b694ad0225ecc36a66b226afa2c8cd931656