### PR TITLE
Submitting a blank search should return all results, bring in line wi…

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -254,6 +254,10 @@ class CatalogController < ApplicationController
     config.add_results_collection_tool :save_search
   end
 
-
-
+  ##
+  # Overrides default Blacklight method to return true for an empty q value
+  # @return [Boolean]
+  def has_search_parameters?
+    !params[:q].nil? || super
+  end
 end

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 feature 'Custom facets' do
   feature 'dc_rights_s' do
     scenario 'should handle a query, but not show up in facet bar' do
-      visit catalog_index_path(q: '*', f: { dc_rights_s: ['Restricted'] })
+      visit catalog_index_path(q: '', f: { dc_rights_s: ['Restricted'] })
       expect(page).to_not have_css '.facet_select', text: 'Rights'
       expect(page).to have_css '.filterName', text: 'Rights'
       expect(page).to have_css '.document', count: 2

--- a/spec/features/page_title_spec.rb
+++ b/spec/features/page_title_spec.rb
@@ -8,7 +8,7 @@ feature 'Main page title' do
 end
 feature 'Search results' do
   scenario 'have title' do
-    visit catalog_index_path q: '*'
+    visit catalog_index_path q: ''
     expect(page.title).to eq 'EarthWorks Search Results'
   end
 end


### PR DESCRIPTION
…th SearchWorks behavior

I think the logic is flawed in Blacklight. Submitting a PR upstream https://github.com/projectblacklight/blacklight/blob/73df5d37598191db427c506dc08cef1a8f3ce96c/app/controllers/concerns/blacklight/catalog.rb#L108

Closes #278 
Closes #270 