### PR TITLE
Create a Earthworks::SearchBuilder to make spatial search results mor…

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -31,8 +31,8 @@ class CatalogController < ApplicationController
 
     config.show.display_type_field = 'format'
 
-    config.search_builder_class = Geoblacklight::SearchBuilder
-    
+    config.search_builder_class = Earthworks::SearchBuilder
+
     # Custom GeoBlacklight fields which currently map to GeoBlacklight-Schema
     # v0.3.2
     config.wxs_identifier_field = 'layer_id_s'

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,7 @@ module Earthworks
     require 'suggest/response'
     require 'suggest/search_helper'
     require 'suggest'
+    require 'search_builder'
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/lib/search_builder.rb
+++ b/lib/search_builder.rb
@@ -1,0 +1,19 @@
+module Earthworks
+  ##
+  # Custom SearchBuilder for EarthWorks that gives larger boost IsWithin
+  class SearchBuilder < Geoblacklight::SearchBuilder
+    def add_spatial_params(solr_params)
+      if blacklight_params[:bbox]
+        solr_params[:bq] ||= []
+        solr_params[:bq] =
+          ["#{Settings.GEOMETRY_FIELD}:\"IsWithin(#{envelope_bounds})\"^300"]
+        solr_params[:fq] ||= []
+        solr_params[:fq] <<
+          "#{Settings.GEOMETRY_FIELD}:\"Intersects(#{envelope_bounds})\""
+      end
+      solr_params
+    rescue Geoblacklight::Exceptions::WrongBoundingBoxFormat
+      solr_params
+    end
+  end
+end

--- a/spec/integration/external-data/geo_search_spec.rb
+++ b/spec/integration/external-data/geo_search_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+feature 'Spatial search', feature: true, :'data-integration' => true do
+  scenario 'isWithin should be more relevant' do
+    visit catalog_index_path(q: 'road', bbox: '61.34 2.11 92 40.45')
+    expect(page).to have_css 'h3.index_title', text: '1. Roads: Badakhshān Pr' \
+      'ovince, Afghanistan, 2005'
+  end
+end

--- a/spec/lib/search_builder_spec.rb
+++ b/spec/lib/search_builder_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe Earthworks::SearchBuilder do
+  let(:method_chain) { CatalogController.search_params_logic }
+  let(:user_params) { Hash.new }
+  let(:solr_params) { Hash.new }
+  let(:context) { CatalogController.new }
+
+  let(:search_builder) { described_class.new(method_chain, context) }
+
+  subject { search_builder.with(user_params) }
+  describe '#add_spatial_params' do
+    it 'should return the solr_params when no bbox is given' do
+      expect(subject.add_spatial_params(solr_params)).to eq solr_params
+    end
+
+    it 'should return a spatial search if bbox is given' do
+      params = { bbox: '-180 -80 120 80' }
+      subject.with(params)
+      expect(subject.add_spatial_params(solr_params)[:fq].to_s)
+        .to include('Intersects')
+      expect(subject.add_spatial_params(solr_params)[:bq].to_s)
+        .to match(/.*IsWithin.*\^300/)
+    end
+  end
+end


### PR DESCRIPTION
…e relevant

On some searches (test + spatial) global datasets that matched term search were consistently ranked higher and would bump out other results. I think this approach provides for a better result for user. Also added index integration test.