### PR TITLE
Updates the typeahead code and styling to deal with an update.

### DIFF
--- a/app/assets/javascripts/modules/autocomplete.js
+++ b/app/assets/javascripts/modules/autocomplete.js
@@ -3,7 +3,8 @@ $(document).on('ready page:load', function() {
     datumTokenizer: Bloodhound.tokenizers.obj.whitespace('value'),
     queryTokenizer: Bloodhound.tokenizers.whitespace,
     remote: {
-      url: '/suggest?q=%QUERY'
+      url: '/suggest?q=%QUERY',
+      wildcard: '%QUERY'
     }
   });
 

--- a/app/assets/stylesheets/modules/typeahead.scss
+++ b/app/assets/stylesheets/modules/typeahead.scss
@@ -11,13 +11,13 @@
     width: 100%;
   }
 
-  .tt-dropdown-menu {
+  .tt-menu {
     @extend .dropdown-menu;
     font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; 
     
     width: 100%;
 
-    .tt-suggestion p{
+    .tt-suggestion{
       font-size: 14px;
       padding-left: 10px;
     }


### PR DESCRIPTION
Library update was introduced in 7ae205be4a3e1337e996b50f4f5b8ebdd1c930fe. This
type of test is nearly impossible to created.

Closes #299 