### PR TITLE
Updates capistrano to dept standards

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,16 +1,10 @@
-# config valid only for Capistrano 3.4.0
-lock '3.4.0'
-
 set :application, 'earthworks'
 set :repo_url, 'https://github.com/sul-dlss/earthworks.git'
-set :user, 'geostaff'
-
 
 # Default branch is :master
 ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call
-set :home_directory, "/opt/app/#{fetch(:user)}"
 
-set :deploy_to, "#{fetch(:home_directory)}/#{fetch(:application)}"
+set :deploy_to, '/opt/app/geostaff/earthworks'
 
 # Default value for :scm is :git
 # set :scm, :git

--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -1,7 +1,6 @@
-set :deploy_host, 'kurma-earthworks-dev.stanford.edu'
-set :bundle_without, %w{sqlite production test}.join(' ')
+set :bundle_without, %w[sqlite production test].join(' ')
 
-server fetch(:deploy_host), user: fetch(:user), roles: %w{web db app}
+server 'kurma-earthworks-dev.stanford.edu', user: 'geostaff', roles: %w[web db app]
 
 Capistrano::OneTimeKey.generate_one_time_key!
-set :rails_env, "development"
+set :rails_env, 'development'

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,13 +1,9 @@
 # Deploys to all production nodes
 
-set :deploy_host, 'kurma-earthworks'
-set :bundle_without, %w{sqlite test development}.join(' ')
+set :bundle_without, %w[sqlite test development].join(' ')
 
-server_extensions = [1, 2]
-
-server_extensions.each do |extension|
-  server "#{fetch(:deploy_host)}#{extension}-prod.stanford.edu", user: fetch(:user), roles: %w{web db app}
-end
+server 'kurma-earthworks1-prod.stanford.edu', user: 'geostaff', roles: %w[web db app]
+server 'kurma-earthworks2-prod.stanford.edu', user: 'geostaff', roles: %w[web db app]
 
 Capistrano::OneTimeKey.generate_one_time_key!
-set :rails_env, "production"
+set :rails_env, 'production'

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,7 +1,6 @@
-set :deploy_host, 'kurma-earthworks-stage.stanford.edu'
-set :bundle_without, %w{sqlite production test development}.join(' ')
+set :bundle_without, %w[sqlite production test development].join(' ')
 
-server fetch(:deploy_host), user: fetch(:user), roles: %w{web db app}
+server 'kurma-earthworks-stage.stanford.edu', user: 'geostaff', roles: %w[web db app]
 
 Capistrano::OneTimeKey.generate_one_time_key!
-set :rails_env, "stage"
+set :rails_env, 'stage'


### PR DESCRIPTION
explicitly states `server` name and `deploy_to`