### PR TITLE
update GeoBlacklight icons to get new types

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,7 @@ GEM
       leaflet-rails (~> 0.7.3)
       mime-types
       rails (~> 5.0)
-    geoblacklight-icons (1.1.0)
+    geoblacklight-icons (1.2.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     honeybadger (3.2.0)
@@ -462,4 +462,4 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
 
 BUNDLED WITH
-   1.16.0
+   1.16.1


### PR DESCRIPTION
Resolves missing icons here:

<img width="204" alt="screen shot 2018-01-11 at 9 42 21 am" src="https://user-images.githubusercontent.com/1656824/34836003-c55b0456-f6b3-11e7-9a1a-e7dbd4115afc.png">

Closes #316 