### PR TITLE
explicitly configure sidekiq workers

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -11,4 +11,4 @@ Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'
 
 set :sidekiq_role, :background
-set :sidekiq_processes, 10
+set :sidekiq_processes, 5

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -7,4 +7,4 @@ Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'
 
 set :sidekiq_role, :background
-set :sidekiq_processes, 10
+set :sidekiq_processes, 5

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,3 @@
+# concurrency per process should match the database connection pool size
+---
+:concurrency: 5


### PR DESCRIPTION
this gives us 25 workers -- 5 processes each with 5 workers -- so that we can use the default 5 db connections in the pool as defined in `config/database.yml`