### PR TITLE
update page title for search results page

### DIFF
--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -9,6 +9,8 @@ en:
       show:
         title_html: '%{document_title} in %{application_name}'
         label: '%{label}'
+      fields:
+        search: 'Keywords'
     search_history:
       save: 'Save this search'
       forget: 'Forget this search'

--- a/spec/features/page_title_spec.rb
+++ b/spec/features/page_title_spec.rb
@@ -8,8 +8,8 @@ feature 'Main page title' do
 end
 feature 'Search results' do
   scenario 'have title' do
-    visit search_catalog_path q: ''
-    expect(page.title).to eq ' - EarthWorks Search Results'
+    visit search_catalog_path q: 'california'
+    expect(page.title).to eq 'Keywords: california - EarthWorks Search Results'
   end
 end
 feature 'Show page' do


### PR DESCRIPTION
This fixes an issue where a search result would provide a strange html title

![screen shot 2018-01-25 at 10 45 06 am](https://user-images.githubusercontent.com/1656824/35403415-da4a67ee-01bc-11e8-8819-25e420931d15.png)
