### PR TITLE
add shared_configs refreshes to capistrano deploys

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -25,7 +25,7 @@ require 'dlss/capistrano'
 require 'capistrano/sitemap_generator'
 require 'capistrano/sidekiq'
 require 'whenever/capistrano'
-
+require 'capistrano/shared_configs'
 
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ group :deployment do
   gem 'capistrano-rails'
   gem 'dlss-capistrano'
   gem 'capistrano-sidekiq'
+  gem 'capistrano-shared_configs'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -432,6 +432,7 @@ DEPENDENCIES
   capistrano-bundler
   capistrano-rails
   capistrano-rvm
+  capistrano-shared_configs
   capistrano-sidekiq
   capybara
   coffee-rails (~> 4.2.2)


### PR DESCRIPTION
This PR will refresh our shared_configs on any deploy. Right now, it's not doing it afaict.