### PR TITLE
update sitemap generation code and add cronjob for prod

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -2,8 +2,8 @@
 
 set :bundle_without, %w[test development deployment].join(' ')
 
-server 'kurma-earthworks1-prod.stanford.edu', user: 'geostaff', roles: %w[web db app whenevs]
-server 'kurma-earthworks2-prod.stanford.edu', user: 'geostaff', roles: %w[web db app]
+server 'kurma-earthworks1-prod.stanford.edu', user: 'geostaff', roles: %w[web db app whenevs sitemap]
+server 'kurma-earthworks2-prod.stanford.edu', user: 'geostaff', roles: %w[web db app sitemap]
 server 'kurma-earthworks-worker-prod-a.stanford.edu', user: 'geostaff', roles: %w[app background]
 
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -32,3 +32,7 @@ end
 every 2.days, roles: %i[whenevs] do
   rake 'earthworks:geomonitor:check_public'
 end
+
+every 1.week, roles: %i[sitemap] do
+  rake 'sitemap:refresh'
+end

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -5,8 +5,8 @@ require 'blacklight'
 require 'sitemap_generator'
 
 # fetch all the slugs and their last modified (indexed) date
-# solr = RSolr.connect(:url => SOLR_URL, :read_timeout => 300)
-response = Blacklight.solr.get 'select', :params => {
+solr = Blacklight.default_index.connection
+response = solr.get 'select', :params => {
   :q => '*:*',
   :facet => 'false',
   :rows => 1000000, # keep this very large


### PR DESCRIPTION
Fixes #362 by changing `Blacklight.solr` to `Blacklight.default_index.connection` for the latest Blacklight release. It also installs a cron job to run `sitemap:refresh` once a week on both prod machines.