### PR TITLE
cap deploy fixes

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -32,7 +32,7 @@ set :linked_dirs, %w{config/settings log tmp/pids tmp/cache tmp/sockets vendor/b
 
 set :honeybadger_env, fetch(:stage)
 
-set :whenever_roles, [:whenevs]
+set :whenever_roles, [:whenevs, :sitemap]
 
 # update shared_configs before restarting app
 before 'deploy:restart', 'shared_configs:update'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -34,6 +34,9 @@ set :honeybadger_env, fetch(:stage)
 
 set :whenever_roles, [:whenevs]
 
+# update shared_configs before restarting app
+before 'deploy:restart', 'shared_configs:update'
+
 namespace :deploy do
 
   desc 'Restart application'


### PR DESCRIPTION
Missed these in the cap deploy:

- add sitemap to whenever roles in deploy.rb
- add shared_configs:update hook to deploy.rb