### PR TITLE
make sure leaflet's zoom control buttons aren't underlined

### DIFF
--- a/app/assets/stylesheets/modules/base_styles.scss
+++ b/app/assets/stylesheets/modules/base_styles.scss
@@ -1,3 +1,3 @@
-a:not(.btn) {
+a:not(.btn):not(.leaflet-control-zoom-in):not(.leaflet-control-zoom-out) {
   text-decoration: underline;
 }


### PR DESCRIPTION
i'm _pretty_ sure this fix is all you need.

![screenshot 2018-11-07 14 05 26](https://user-images.githubusercontent.com/3011734/48164029-33fd2500-e296-11e8-8f47-a70249dcb4d9.png)

disclaimer: i did **not** test this fix locally because solr threw a weird error when i tried to spin it up.