### PR TITLE
adds script to update caching for every layer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -388,7 +388,7 @@ GEM
     simplecov-html (0.10.2)
     sitemap_generator (6.0.1)
       builder (~> 3.0)
-    solr_wrapper (2.0.0)
+    solr_wrapper (2.1.0)
       faraday
       retriable
       ruby-progressbar

--- a/scripts/geoserver/update_caching.rb
+++ b/scripts/geoserver/update_caching.rb
@@ -1,0 +1,66 @@
+require 'faraday'
+require 'nokogiri'
+
+##
+# This script updates the caching default for each individual layer that we
+# host. Unfortunately there is no global way to set this, so it has to happen
+# on a per layer basis.
+
+geoserver_url = ENV['GEOSERVER_URL']
+
+raise('GEOSERVER_URL not provided') unless geoserver_url
+raise('GEOSERVER_USER not provided') unless ENV['GEOSERVER_USER']
+raise('GEOSERVER_PASS not provided') unless ENV['GEOSERVER_PASS']
+
+puts "Updating cache defaults for all layers on #{geoserver_url}"
+
+conn = Faraday.new(url: geoserver_url) do |faraday|
+  faraday.basic_auth(ENV['GEOSERVER_USER'], ENV['GEOSERVER_PASS'])
+  faraday.adapter :net_http
+end
+
+layers_response = conn.get do |req|
+  req.url 'geoserver/rest/layers.xml'
+  req.options.timeout = 30
+end
+
+layer_names = Nokogiri::XML(layers_response.body).xpath('//layer/name').map(&:text)
+puts "Found #{layer_names.length} layers"
+Nokogiri::XML(layers_response.body).xpath('//layer').each do |layer|
+  name = layer.xpath('name').text
+  layer_rest = layer.xpath('atom:link', atom: 'http://www.w3.org/2005/Atom').attribute('href').to_s
+
+  layer_response = conn.get do |req|
+    req.url layer_rest.gsub(geoserver_url, '')
+  end.body
+
+  layer_update = Nokogiri::XML(layer_response).xpath('//resource/atom:link', atom: 'http://www.w3.org/2005/Atom').attribute('href').to_s
+  current_config = conn.get do |req|
+    req.url layer_update.gsub(geoserver_url, '')
+  end.body
+  metadata = Nokogiri::XML.fragment(
+    <<~XML
+      <metadata>
+        <entry key="cacheAgeMax">86400</entry>
+        <entry key="cachingEnabled">true</entry>
+      </metadata>
+    XML
+  )
+  new_config = Nokogiri::XML(current_config)
+  # Replace existing metadata element
+  if new_config.search('metadata').first
+    new_config.search('metadata').first.replace(metadata)
+  else
+    # or just put it at the root
+    new_config.xpath('/').first.root << metadata
+  end
+  print "Updating #{name} at #{layer_update}"
+  print ' ... '
+  update = conn.put do |req|
+    req.url layer_update.gsub(geoserver_url, '')
+    req.headers['Content-Type'] = 'text/xml'
+    req.body = new_config.to_xml
+  end
+  print update.status
+  puts ''
+end

--- a/scripts/geowebcache/add_gridsets.rb
+++ b/scripts/geowebcache/add_gridsets.rb
@@ -45,6 +45,9 @@ layer_names.each do |name|
             <gridSetName>EPSG:900913 - 512</gridSetName>
           </gridSubset>
           <gridSubset>
+            <gridSetName>EPSG:3857 - 512</gridSetName>
+          </gridSubset>
+          <gridSubset>
             <gridSetName>EPSG:4326 - 512</gridSetName>
           </gridSubset>
         </gridSubsets>


### PR DESCRIPTION
Related to #472 

We need to remediate every layer already in GeoServer, to add WMS tile caching . This will set the Cache-Control max-age header, and unfortunately there is no way to do this globally.