### PR TITLE
Make sure oembed content is available for preview/download

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper
   def document_unavailable_options(document)
     options = []
-    options.push 'download' unless document.direct_download || document.download_types.present? || document.iiif_download.present?
+    options.push 'download' unless document.direct_download || document.download_types.present? || document.iiif_download.present? || document.oembed.present?
     options.push('preview', 'download') unless document_available? || document.stanford? || document.restricted?
     options
   end

--- a/spec/features/unavailable_layer_spec.rb
+++ b/spec/features/unavailable_layer_spec.rb
@@ -13,6 +13,10 @@ feature 'Unavailable layer' do
     visit solr_document_path'princeton-02870w62c'
     expect(page).to_not have_content 'unavailable to download'
   end
+  scenario 'oembed layer' do
+    visit solr_document_path'stanford-dt131hw5005'
+    expect(page).to_not have_content 'unavailable to preview and download'
+  end
   scenario 'catalog index page should have availablility facets' do
     visit search_catalog_path q: '*'
     expect(page).to have_css '.facet-select', text: 'Unavailable'

--- a/spec/fixtures/solr_documents/stanford-paper-map.json
+++ b/spec/fixtures/solr_documents/stanford-paper-map.json
@@ -1,0 +1,27 @@
+{
+  "dc_identifier_s": "http://purl.stanford.edu/dt131hw5005",
+  "dc_title_s": "Buffer Zone Study, Stanford University. Eldridge T. Spencer. 1955",
+  "dc_description_s": "Stanford University campus buffer zone study prepared by the Stanford University Planning Office. Digitized by Stanford University Libraries.",
+  "dc_rights_s": "Public",
+  "layer_geom_type_s": "Image",
+  "dc_type_s": "Image",
+  "dc_format_s": "JPEG 2000",
+  "dc_language_s": "English",
+  "dc_subject_sm": [
+    "Stanford University Lands",
+    "Stanford University Campus"
+  ],
+  "dct_spatial_sm": [
+    "Palo Alto (Calif.)",
+    "Stanford (Calif.)"
+  ],
+  "dc_creator_sm": [
+    "Spencer, Eldridge T"
+  ],
+  "geoblacklight_version": "1.0",
+  "dct_references_s": "{\"http://schema.org/url\":\"https://purl.stanford.edu/dt131hw5005\",\"https://oembed.com\":\"https://purl.stanford.edu/embed.json?&hide_title=true&url=https://purl.stanford.edu/dt131hw5005\",\"http://iiif.io/api/presentation#manifest\":\"https://purl.stanford.edu/dt131hw5005/iiif/manifest\"}",
+  "solr_geom": "ENVELOPE(-122.191292, -122.149475, 37.4435369, 37.4063388)",
+  "layer_slug_s": "stanford-dt131hw5005",
+  "dct_provenance_s": "Stanford",
+  "stanford_rights_metadata_s": "<rightsMetadata>\n    <access type=\"discover\">\n      <machine>\n        <world/>\n      </machine>\n    </access>\n    <access type=\"read\">\n      <machine>\n        <world/>\n      </machine>\n    </access>\n    <use>\n      <human type=\"useAndReproduction\">Property rights reside with the repository. Literary rights reside with  the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).</human>\n    </use>\n    <use>\n      <human type=\"creativeCommons\"/>\n      <machine type=\"creativeCommons\"/>\n    </use>\n  </rightsMetadata>"
+}


### PR DESCRIPTION
Without this, we will display a message to the user that the content is unavailable. Similar to our IIIF / availability that does not have GeoMonitor status checking