### PR TITLE
Pin dlss-capistrano to 3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ group :deployment do
   gem 'capistrano-rvm'
   gem 'capistrano-bundler'
   gem 'capistrano-rails'
-  gem 'dlss-capistrano'
+  gem 'dlss-capistrano', '~> 3.5'
   gem 'capistrano-sidekiq'
   gem 'capistrano-shared_configs'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -460,7 +460,7 @@ DEPENDENCIES
   devise
   devise-guests (>= 0.3.3)
   devise-remote-user
-  dlss-capistrano
+  dlss-capistrano (~> 3.5)
   factory_bot_rails
   geo_combine!
   geo_monitor (~> 0.4)


### PR DESCRIPTION
Do this because when dlss-capistrano 4.0 comes out, codebases that use both dlss-capistrano and capistrano-sidekiq without pinning the former will find it clobbering the sidekiq tasks from the latter, and that will cause confusion and woe.