### PR TITLE
Add an oembed css module with an override for explicit map heights…

### DIFF
--- a/app/assets/stylesheets/earthworks.scss
+++ b/app/assets/stylesheets/earthworks.scss
@@ -6,6 +6,7 @@
 @import 'modules/home';
 @import 'modules/icons';
 @import 'modules/leaflet';
+@import 'modules/oembed';
 @import 'modules/show';
 @import 'modules/sul_footer';
 @import 'modules/top_navbar';

--- a/app/assets/stylesheets/modules/oembed.scss
+++ b/app/assets/stylesheets/modules/oembed.scss
@@ -1,0 +1,9 @@
+// Override the explicit height set on [data-map="item"] for leaflet maps to be
+// auto-height when coming from Oembed (which should manage its own height)
+#document {
+  #viewer-container {
+    [data-map="item"][data-protocol="Oembed"] {
+      height: auto;
+    }
+  }
+}


### PR DESCRIPTION
… applied to oembed viewers.

Closes #650 

## stanford-cg357zz0321 (before / after, no change)
<img width="925" alt="stanford-cg357zz0321-after" src="https://user-images.githubusercontent.com/96776/85049947-39953f00-b14a-11ea-872e-f851c01a1416.png">

## stanford-dt131hw5005 (before)
<img width="895" alt="stanford-dt131hw5005-before" src="https://user-images.githubusercontent.com/96776/85050003-4c0f7880-b14a-11ea-8cc4-46e3ff515d00.png">

## stanford-dt131hw5005 (after)
<img width="917" alt="stanford-dt131hw5005-after" src="https://user-images.githubusercontent.com/96776/85050012-4fa2ff80-b14a-11ea-9b08-6193b968c27a.png">
