### PR TITLE
Update vector data with styling appropriate to the geom type

### DIFF
--- a/scripts/geoserver/set_wms_default_style.rb
+++ b/scripts/geoserver/set_wms_default_style.rb
@@ -12,6 +12,14 @@ raise('GEOSERVER_URL not provided') unless geoserver_url
 raise('GEOSERVER_USER not provided') unless ENV['GEOSERVER_USER']
 raise('GEOSERVER_PASS not provided') unless ENV['GEOSERVER_PASS']
 
+solr_data = Faraday.get('https://sul-solr-a.stanford.edu/solr/kurma-earthworks-v1-prod/select?fl=layer_slug_s,layer_geom_type_s&q=dct_provenance_s:Stanford&fq=-layer_geom_type_s:Raster&fq=-layer_geom_type_s:Image&rows=20000&wt=csv&csv.header=false')
+expected_styles = solr_data.body.split("\n").each_with_object({}) do |row, hash|
+  slug, geom = row.split(',', 2)
+  _, druid = slug.split('-', 2)
+
+  hash[druid] = geom.downcase
+end
+
 puts "Updating WMS default style for all vector layers on #{geoserver_url}"
 
 conn = Faraday.new(url: geoserver_url) do |faraday|
@@ -28,34 +36,38 @@ layer_names = Nokogiri::XML(layers_response.body).xpath('//layer/name').map(&:te
 puts "Found #{layer_names.length} layers"
 Nokogiri::XML(layers_response.body).xpath('//layer').each do |layer|
   name = layer.xpath('name').text
+  druid = name.strip.sub('druid:', '')
+
   layer_rest = layer.xpath('atom:link', atom: 'http://www.w3.org/2005/Atom').attribute('href').to_s
 
   layer_response = conn.get do |req|
     req.url layer_rest.gsub(geoserver_url, '')
   end.body
   parsed_response = Nokogiri::XML(layer_response)
-  if parsed_response.xpath('//type').text == 'VECTOR'
-    print "#{name} is a vector"
-    style = parsed_response.xpath('//defaultStyle').text.strip
-    unless style.length > 0
-      print ' no defaultStyle is set setting to generic '
-      generic_style =
-        <<~XML
-          <layer>
-            <defaultStyle>
-              <name>generic</name>
-            </defaultStyle>
-          </layer>
-        XML
-      update = conn.put do |req|
-        req.url layer_rest.gsub(geoserver_url, '')
-        req.headers['Content-Type'] = 'text/xml'
-        req.body = generic_style
-      end
-      puts update.status
+  next unless parsed_response.xpath('//type').text == 'VECTOR'
 
-    else
-      puts " defaultStyle is already set as #{style}"
+  print "#{name} is a vector; "
+  style = parsed_response.xpath('//defaultStyle').text.strip
+
+  expected_style = expected_styles[druid] || 'generic'
+
+  if style != expected_style && (style.empty? || style == 'generic')
+    print " setting style (current: '#{style}') to '#{expected_styles[druid]}'"
+    generic_style =
+      <<~XML
+        <layer>
+          <defaultStyle>
+            <name>#{expected_styles[druid]}</name>
+          </defaultStyle>
+        </layer>
+      XML
+    update = conn.put do |req|
+      req.url layer_rest.gsub(geoserver_url, '')
+      req.headers['Content-Type'] = 'text/xml'
+      req.body = generic_style
     end
+    puts update.status
+  else
+    puts " defaultStyle is already set as #{style}"
   end
 end


### PR DESCRIPTION
Part of #636 

As a sampling of what it might do:
```
druid:zp324qp2900 is a vector; setting style (current: 'generic') to 'point'
druid:gy803bb5537 is a vector; setting style (current: 'generic') to 'polygon'
druid:ky867fv0017 is a vector; setting style (current: 'generic') to 'polygon'
druid:rx587qp9828 is a vector; defaultStyle is already set as polygon
druid:pt147bd6286 is a vector; setting style (current: 'generic') to 'polygon'
druid:yz347jp3502 is a vector; setting style (current: 'generic') to 'polygon'
druid:zs804mh1899 is a vector; setting style (current: 'generic') to 'polygon'
druid:vm491bz1561 is a vector; setting style (current: 'generic') to 'polygon'
druid:qv391sc1991 is a vector; setting style (current: 'generic') to 'polygon'
druid:ym783mg1598 is a vector; setting style (current: 'generic') to 'polygon'
druid:jm039td8162 is a vector; setting style (current: 'generic') to 'line'
druid:gr911gs9795 is a vector; setting style (current: 'generic') to 'polygon'
druid:db689pf6451 is a vector; setting style (current: 'generic') to 'polygon'
druid:wh862rq6780 is a vector; setting style (current: 'generic') to 'polygon'
druid:ws772ry9889 is a vector; setting style (current: 'generic') to 'polygon'
druid:sz981gp0750 is a vector; setting style (current: 'generic') to 'polygon'
druid:yw234jf3747 is a vector; setting style (current: 'generic') to 'line'
druid:xs890yk1877 is a vector; setting style (current: 'generic') to 'polygon'
druid:dq526np3789 is a vector; setting style (current: 'generic') to 'point'
druid:cj223yb5489 is a vector; defaultStyle is already set as polygon
druid:dq224ck3147 is a vector; setting style (current: 'generic') to 'polygon'
druid:jk220kp8398 is a vector; setting style (current: 'generic') to 'polygon'
druid:jr169rs1653 is a vector; setting style (current: 'generic') to 'polygon'
druid:kg342gc4695 is a vector; setting style (current: 'generic') to 'polygon'
druid:rr545tb3764 is a vector; setting style (current: 'generic') to 'polygon'
druid:rx146gp6498 is a vector; setting style (current: 'generic') to 'polygon'
druid:qc239zr0046 is a vector; setting style (current: 'generic') to 'polygon'
druid:qr641bc6786 is a vector; setting style (current: 'generic') to 'polygon'
druid:cm303jw5428 is a vector; setting style (current: 'generic') to 'polygon'
druid:wd748sr6042 is a vector; setting style (current: 'generic') to 'polygon'
```