### PR TITLE
Remove blank field values when documents are indexed.

### DIFF
--- a/config/solr_configs/solrconfig.xml
+++ b/config/solr_configs/solrconfig.xml
@@ -38,22 +38,24 @@
     </autoCommit>
   </updateHandler>
 
-  <updateRequestProcessorChain name="add_hashed_id">
-    <processor class="solr.processor.SignatureUpdateProcessorFactory">
-      <bool name="enabled">true</bool>
-      <str name="signatureField">hashed_id_ssi</str>
-      <bool name="overwriteDupes">false</bool>
-      <str name="fields">layer_slug_s</str>
-      <str name="signatureClass">solr.processor.Lookup3Signature</str>
-    </processor>
+  <updateProcessor class="solr.processor.SignatureUpdateProcessorFactory" name="add_hashed_id">
+    <bool name="enabled">true</bool>
+    <str name="signatureField">hashed_id_ssi</str>
+    <bool name="overwriteDupes">false</bool>
+    <str name="fields">layer_slug_s</str>
+    <str name="signatureClass">solr.processor.Lookup3Signature</str>
+  </updateProcessor>
 
+  <updateProcessor class="solr.RemoveBlankFieldUpdateProcessorFactory" name="remove_blanks" />
+
+  <updateRequestProcessorChain name="earthworks-processor" processor="remove_blanks,add_hashed_id">
     <processor class="solr.LogUpdateProcessorFactory" />
     <processor class="solr.RunUpdateProcessorFactory" />
   </updateRequestProcessorChain>
 
   <requestHandler name="/update" class="solr.UpdateRequestHandler">
     <lst name="defaults">
-      <str name="update.chain">add_hashed_id</str>
+      <str name="update.chain">earthworks-processor</str>
     </lst>
   </requestHandler>
 

--- a/config/solr_configs/solrconfig.xml
+++ b/config/solr_configs/solrconfig.xml
@@ -38,17 +38,9 @@
     </autoCommit>
   </updateHandler>
 
-  <updateProcessor class="solr.processor.SignatureUpdateProcessorFactory" name="add_hashed_id">
-    <bool name="enabled">true</bool>
-    <str name="signatureField">hashed_id_ssi</str>
-    <bool name="overwriteDupes">false</bool>
-    <str name="fields">layer_slug_s</str>
-    <str name="signatureClass">solr.processor.Lookup3Signature</str>
-  </updateProcessor>
-
   <updateProcessor class="solr.RemoveBlankFieldUpdateProcessorFactory" name="remove_blanks" />
 
-  <updateRequestProcessorChain name="earthworks-processor" processor="remove_blanks,add_hashed_id">
+  <updateRequestProcessorChain name="earthworks-processor" processor="remove_blanks">
     <processor class="solr.LogUpdateProcessorFactory" />
     <processor class="solr.RunUpdateProcessorFactory" />
   </updateRequestProcessorChain>

--- a/spec/features/record_spec.rb
+++ b/spec/features/record_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Record view' do
+  it 'does not have empty values indexed' do
+    visit solr_document_path('columbia-columbia-landinfo-global-aet')
+
+    expect(page).not_to have_css('dt', text: 'Publisher')
+  end
+end

--- a/spec/fixtures/solr_documents/actual-point1.json
+++ b/spec/fixtures/solr_documents/actual-point1.json
@@ -6,6 +6,7 @@
   "dc_language_s": "English",
   "dc_rights_s": "Public",
   "dc_title_s": "Actual Evapotrans",
+  "dc_publisher_s": "",
   "dc_type_s": "Dataset",
   "dct_references_s": "{\"http://www.opengis.net/cat/csw/csdgm\":\"http://opengeometadata.stanford.edu/metadata/org.opengeoportal/Columbia:Columbia.landinfo_global_aet/fgdc.xml\",\"http://www.w3.org/1999/xhtml\":\"http://opengeometadata.stanford.edu/metadata/org.opengeoportal/Columbia:Columbia.landinfo_global_aet/fgdc.html\"}",
   "dct_spatial_sm": [


### PR DESCRIPTION
Closes #644 

Adds an earthworks-processor that allows us to combine multiple processors.

Adds RemoveBlankFieldUpdateProcessorFactory to the earthworks-processor (in addition to the hashed id processor)

Note: these screenshots are using local fixtures and not production data.  I tested this w/ the ~4k NYU records locally and this fixed the issue for the 56 records that has blank publishers.

## columbia-columbia-landinfo-global-aet (before)
<img width="878" alt="columbia-columbia-landinfo-global-aet-before" src="https://user-images.githubusercontent.com/96776/86054748-8a8d1900-ba0f-11ea-9f95-ef84daeaf84d.png">

## columbia-columbia-landinfo-global-aet (after)
<img width="866" alt="columbia-columbia-landinfo-global-aet-after" src="https://user-images.githubusercontent.com/96776/86054752-8d880980-ba0f-11ea-9f6a-582a8f791734.png">
