### PR TITLE
Fixes #710 by updating keys for data relations widget

### DIFF
--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -2,3 +2,6 @@ en:
   geoblacklight:
     home:
       headline: 'Discover and download GIS data and maps'
+    relations:
+      ancestor: Item belongs to a collection
+      descendant: Collection items


### PR DESCRIPTION
<img width="697" alt="Screen Shot 2020-07-08 at 4 01 31 PM" src="https://user-images.githubusercontent.com/1656824/86975025-9924b000-c134-11ea-96e6-2a893a673636.png">

When https://github.com/geoblacklight/geoblacklight/pull/913 gets merged what we are looking for should automatically be dropped in place.