### PR TITLE
Update styling of homepage

### DIFF
--- a/app/assets/stylesheets/modules/home.scss
+++ b/app/assets/stylesheets/modules/home.scss
@@ -1,3 +1,16 @@
+@mixin homepage-image-border {
+  border: 2px solid rgba(46, 45, 41, 0.1);
+}
+
+.jumbotron {
+  border: 1px solid $gray-80-percent;
+  padding: 2rem 2rem;
+
+  h2 {
+    margin-bottom: 20px;
+  }
+}
+
 .search-block {
   .input-group {
     @extend .flex-nowrap;
@@ -10,7 +23,7 @@
   button.search-btn {
     @extend .btn-lg;
     display: inline-flex;
-    
+
     .blacklight-icons,
     .blacklight-icons svg {
       height: 1.5rem;
@@ -30,10 +43,19 @@
     font-size: 22px;
     font-weight: 300;
     margin-top: 10px;
-    padding-left: 15px;
+    text-align: center;
   }
 
   img {
+    @include homepage-image-border;
     width: 100%;
   }
+}
+
+.section-heading {
+  margin-top: 36px;
+}
+
+#map {
+  @include homepage-image-border;
 }

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -11,8 +11,7 @@
   </div>
 </div>
 <div class='container'>
-  <hr/>
-  <h2 class='font-weight-light'>Explore</h2>
+  <h2 class='font-weight-light section-heading'>Explore</h2>
   <div class='row home-page-linked-searches'>
     <div class='col-sm-3 col-xs-6'>
       <div class='panel panel-default'>
@@ -55,10 +54,9 @@
       </div>
     </div>
   </div>
-  <hr/>
   <div class='row'>
     <div class='col-12'>
-      <h2 class='font-weight-light'>Search an area like California or zoom out to explore</h2>
+      <h2 class='font-weight-light section-heading'>Search an area like California or zoom out to explore</h2>
       <%= content_tag :div, '', id: 'map', data: { map: 'home', 'catalog-path'=> search_catalog_path , 'map-bbox' => '-122.23423 37.37616 -122.11441 37.507002', basemap: geoblacklight_basemap, leaflet_options: leaflet_options } %>
     </div>
   </div>


### PR DESCRIPTION
Some minor updates to give the page elements some vertical breathing room, while keeping overall page height the same:

- Reduced height of jumbotron search background and added some space between heading and search box. Also gave the jumbotron a light border for some definition.

- Removed the two horizontal rules and added some additional vertical whitespace instead.

- Added a light border to the Explore thumbnail images and the big map image. Again, just to give them a bit of definition against the page background (I'm bothered by the way the current Census data image blends into the page background.

- Centered the Explore image titles.

<img width="1098" alt="Screen Shot 2020-07-10 at 2 56 39 PM" src="https://user-images.githubusercontent.com/101482/87206280-3eb75b00-c2be-11ea-96f6-9f494e834681.png">

