### PR TITLE
Explicitly remove right border radiuses from the search input…

### DIFF
--- a/app/assets/stylesheets/modules/blacklight_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_overrides.scss
@@ -1,3 +1,10 @@
 .top-content-title {
   display: none;
 }
+
+.search-query-form {
+  input.search-q {
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0;
+  }  
+}


### PR DESCRIPTION
…(we always join it to a button)

This appears to happen for different-ish reasons on the home page vs. the results page (all to do w/ how bootstrap styles its form controls).  This seemed like the most expedient way to fix it in both cases. Even though bootstrap's input-groups should be handling this for us (I _think_ this is the typeahead markup interfering w/ bootstrap's styling).

## Home Before
<img width="483" alt="home-before" src="https://user-images.githubusercontent.com/96776/87352144-6c471300-c50f-11ea-91fb-eae7cf5e923b.png">

## Home After
<img width="486" alt="home-after" src="https://user-images.githubusercontent.com/96776/87352143-6bae7c80-c50f-11ea-9a4c-3fe59e3380fe.png">

## Results Before
<img width="529" alt="results-before" src="https://user-images.githubusercontent.com/96776/87352145-6cdfa980-c50f-11ea-84e4-2dcef67d3bf9.png">

## Results After
<img width="530" alt="results-after" src="https://user-images.githubusercontent.com/96776/87352147-6cdfa980-c50f-11ea-8638-de111ea68076.png">
