### PR TITLE
Add an explicit width to the .navbar-brand to prevent the image-replaced text from showing

### DIFF
--- a/app/assets/stylesheets/modules/header_navbar.scss
+++ b/app/assets/stylesheets/modules/header_navbar.scss
@@ -7,6 +7,7 @@
     flex: 0 0 175px;
     height: auto;
     line-height: 30px;
+    width: 175px;
   }
 }
 


### PR DESCRIPTION
Before (safari):
![Screen Shot 2020-07-13 at 15 20 47](https://user-images.githubusercontent.com/111218/87359346-6f94cb80-c51c-11ea-94c0-b708b1def2ca.png)

After:
![Screen Shot 2020-07-13 at 15 21 00](https://user-images.githubusercontent.com/111218/87359361-77ed0680-c51c-11ea-9020-9c5d77aa6e9f.png)
