### PR TITLE
Update link hover styles to use a bottom border instead of …

### DIFF
--- a/app/assets/stylesheets/modules/base_styles.scss
+++ b/app/assets/stylesheets/modules/base_styles.scss
@@ -1,3 +1,15 @@
 body {
   overflow-x: hidden;
 }
+
+a {
+  border-bottom: 1px solid transparent;
+  text-decoration: none;
+
+  &:active,
+  &:focus,
+  &:hover {
+    border-bottom: 1px solid $link-hover-color;
+    text-decoration: none;
+  }
+}


### PR DESCRIPTION
…text-decoration.

Closes #693 

This is appears to be the last part of #693.  The link color had already been addressed.

## Before
![link-styling-before](https://user-images.githubusercontent.com/96776/87366726-35342a00-c52e-11ea-9adc-f231a6c1a0cc.gif)

## After
![link-style-after](https://user-images.githubusercontent.com/96776/87366715-31a0a300-c52e-11ea-9fe1-eaf94dcc2b15.gif)

