### PR TITLE
Style links to use a bottom border instead of text-decoration on hover.

### DIFF
--- a/app/assets/stylesheets/modules/base_styles.scss
+++ b/app/assets/stylesheets/modules/base_styles.scss
@@ -1,3 +1,15 @@
 body {
   overflow-x: hidden;
 }
+
+a {
+  border-bottom: 1px solid transparent;
+  text-decoration: none;
+
+  &:active,
+  &:focus,
+  &:hover {
+    border-bottom: solid 1px;
+    text-decoration: none !important;
+  }
+}

--- a/app/assets/stylesheets/modules/header_navbar.scss
+++ b/app/assets/stylesheets/modules/header_navbar.scss
@@ -8,6 +8,10 @@
     height: auto;
     line-height: 30px;
     width: 175px;
+
+    &:hover {
+      border-bottom: 1px solid transparent;
+    }
   }
 }
 

--- a/app/assets/stylesheets/modules/sul_footer.scss
+++ b/app/assets/stylesheets/modules/sul_footer.scss
@@ -54,6 +54,10 @@ $sul-footer-height: 80px;
   display: table-cell;
   vertical-align: middle;
   width: 162px;
+
+  a:hover {
+    border-bottom: 1px solid transparent;
+  }
 }
 
 #sul-footer-links {
@@ -66,4 +70,10 @@ $sul-footer-height: 80px;
 
 #global-footer .container {
   box-sizing: border-box !important;
+
+  #bottom-logo {
+    a:hover {
+      border-bottom: 1px solid transparent;
+    }
+  }
 }

--- a/app/assets/stylesheets/modules/top_navbar.scss
+++ b/app/assets/stylesheets/modules/top_navbar.scss
@@ -10,6 +10,10 @@
   margin-bottom: 0;
   padding: 4px 0;
 
+  .header-logo:hover {
+    border-bottom: 1px solid transparent;
+  }
+
   .topnav-links {
     display: flex;
     margin-left: auto;

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -2,14 +2,14 @@
   <ul class="nav navbar-nav">
     <% if has_user_authentication_provider? && current_or_guest_user.present? %>
     <li class='nav-item'>
-      <%= link_to bookmarks_path, id:'bookmarks_nav', class: 'nav-link' do %>
+      <%= link_to bookmarks_path, id:'bookmarks_nav', class: 'nav-link p-0 m-2' do %>
         <%= t('blacklight.header_links.bookmarks') %>
         (<span data-role='bookmark-counter'><%= current_or_guest_user.bookmarks.count %></span>)
       <% end %>
     </li>
     <% end %>
     <li class='nav-item'>
-      <%= link_to t('blacklight.header_links.search_history'), blacklight.search_history_path, class: 'nav-link' %>
+      <%= link_to t('blacklight.header_links.search_history'), blacklight.search_history_path, class: 'nav-link p-0 m-2' %>
     </li>
   </ul>
 </div>

--- a/app/views/shared/_top_navbar.html.erb
+++ b/app/views/shared/_top_navbar.html.erb
@@ -1,7 +1,7 @@
 <div id="topnav-container">
   <div class='container'>
-    <header id="topnav" class="header-logo" role="banner">
-      <%= link_to 'http://library.stanford.edu' do %>
+    <header id="topnav" role="banner">
+      <%= link_to 'http://library.stanford.edu', class: 'header-logo' do %>
         <%= content_tag :span, "Stanford University Libraries", class: "sr-only" %>
         <%= image_tag "sul-logo.png", alt: "", height: 25 %>
       <% end %>


### PR DESCRIPTION
This also forces no bottom border in a few places we do not want it
(around branding images) and Bootstrap would handle for us with text-decoration.

Another try to close #693 

I did realize that the [spec](https://www.w3.org/TR/CSS21/box.html#border-color-properties) indicates that if a border is applied w/o a color specified it uses the color attribute of that element, so that is helpful. 

This does end up needing us to remove the border in a few place (which is kind of a pain). 

One place where this doesn't quite look right is in the tools menu because of the padding that Bootstrap applies to list group items.
<img width="229" alt="Screen Shot 2020-07-14 at 4 00 38 PM" src="https://user-images.githubusercontent.com/96776/87484707-b6052b80-c5eb-11ea-804c-ea8896fc8fd2.png">

This looks to be all the other links in the site pretty well (but somebody should definitely take this for a spin and see if I'm missing something or should take a diff. approach).