### PR TITLE
Address upstream GeoBlacklight changes

### DIFF
--- a/app/assets/images/blacklight/earthworks-search.svg
+++ b/app/assets/images/blacklight/earthworks-search.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 16 16" class="bi bi-search" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" d="M10.442 10.442a1 1 0 0 1 1.415 0l3.85 3.85a1 1 0 0 1-1.414 1.415l-3.85-3.85a1 1 0 0 1 0-1.415z"/>
+  <path fill-rule="evenodd" d="M6.5 12a5.5 5.5 0 1 0 0-11 5.5 5.5 0 0 0 0 11zM13 6.5a6.5 6.5 0 1 1-13 0 6.5 6.5 0 0 1 13 0z"/>
+</svg>

--- a/app/assets/images/blacklight/exclamation-triangle.svg
+++ b/app/assets/images/blacklight/exclamation-triangle.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 16 16" class="bi bi-exclamation-triangle-fill" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5a.905.905 0 0 0-.9.995l.35 3.507a.552.552 0 0 0 1.1 0l.35-3.507A.905.905 0 0 0 8 5zm.002 6a1 1 0 1 0 0 2 1 1 0 0 0 0-2z"/>
+</svg>

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,8 +3,6 @@
 // Import font first
 @import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro);
 
-@import 'font-awesome';
-
 @import 'sul-variables';
 @import 'blacklight';
 @import 'slider';

--- a/app/assets/stylesheets/modules/zero_results.scss
+++ b/app/assets/stylesheets/modules/zero_results.scss
@@ -1,9 +1,6 @@
 .noresults {
-  .modify-search:before {
-    @extend .fa, .fa-search;
-  }
-
-  .ask-for-dataset:before {
-    @extend .fa, .fa-bullhorn;
+  .ask-for-dataset .icon {
+    display: inline-block;
+    transform: scale(-1, 1);
   }
 }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -288,7 +288,9 @@ class CatalogController < ApplicationController
     # Custom tools for GeoBlacklight
     config.add_show_tools_partial :web_services, if: proc { |_context, _config, options| options[:document] && (Settings.WEBSERVICES_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any? }
     config.add_show_tools_partial :metadata, if: proc { |_context, _config, options| options[:document] && (Settings.METADATA_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any? }
-    config.add_show_tools_partial :exports, partial: 'exports', if: proc { |_context, _config, options| options[:document] }
+    config.add_show_tools_partial :carto, partial: 'carto', if: proc { |_context, _config, options| options[:document] && options[:document].carto_reference.present? }
+    config.add_show_tools_partial :arcgis, partial: 'arcgis', if: proc { |_context, _config, options| options[:document] && options[:document].arcgis_urls.present? }
+    config.add_show_tools_partial :data_dictionary, partial: 'data_dictionary', if: proc { |_context, _config, options| options[:document] && options[:document].data_dictionary_download.present? }
     config.show.document_actions.delete(:sms)
 
     # Configure basemap provider

--- a/app/views/catalog/_show_message.html.erb
+++ b/app/views/catalog/_show_message.html.erb
@@ -3,7 +3,7 @@
 
 <% if document_unavailable.any? %>
   <div class='alert alert-warning unavailable-warning'>
-    <i class='fa fa-exclamation-triangle'></i>
+    <%= blacklight_icon 'exclamation-triangle' %>
     <%= t('earthworks.unavailable_html', institution: document.institution, email: document.contact_email, department: document.department ) %>
   </div>
 <% end %>

--- a/app/views/catalog/_zero_results.html.erb
+++ b/app/views/catalog/_zero_results.html.erb
@@ -1,10 +1,10 @@
 <h2><%= t 'blacklight.search.zero_results.title' %></h2>
 <div id="documents" class="noresults">
-  <h3 class='modify-search'> <%= t 'blacklight.search.zero_results.modify_search' %></h3>
+  <h3 class='modify-search'><%= blacklight_icon 'earthworks-search' %> <%= t 'blacklight.search.zero_results.modify_search' %></h3>
   <ul>
     <li><%= t 'blacklight.search.zero_results.use_fewer_keywords' %></li>
   </ul>
-  <h3 class='ask-for-dataset'> Ask for a dataset to be added</h3>
+  <h3 class='ask-for-dataset'><span class="icon">📢</span> Ask for a dataset to be added</h3>
   <p>You can submit <%= link_to feedback_path, data: { toggle: 'collapse', target: '#feedback-form' } do %>
     feedback
   <% end %> to the <%= link_to 'EarthWorks', root_path %> team requesting data to be added.

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180116174251) do
+ActiveRecord::Schema.define(version: 2020_07_29_150418) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false

--- a/spec/features/open_in_cartodb_spec.rb
+++ b/spec/features/open_in_cartodb_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 feature 'Open in CartoDB' do
   scenario 'item is available' do
     visit solr_document_path'stanford-cz128vq0535'
-    expect(page).to have_css 'li.exports a'
+    expect(page).to have_css 'li.carto a'
   end
   scenario 'item is not available' do
     visit solr_document_path'harvard-ntadcd106'
-    expect(page).to_not have_css 'li.exports a'
+    expect(page).to_not have_css 'li.carto a'
   end
 end


### PR DESCRIPTION
The icon changes for the zero results page seem like they might be the most attention as they are significantly different.

## Zero Results Page (before)
<img width="583" alt="zero-results-before" src="https://user-images.githubusercontent.com/96776/89827998-45c7c800-db0d-11ea-866f-fdb9d2c594b3.png">

## Zero Results Page (after)
<img width="594" alt="zero-results-after" src="https://user-images.githubusercontent.com/96776/89827999-45c7c800-db0d-11ea-948c-08257277fbe2.png">

---

## Unavailable Document (before)
<img width="837" alt="unavailable-doc-before" src="https://user-images.githubusercontent.com/96776/89827992-42ccd780-db0d-11ea-87dc-828d8deb04c4.png">

## Unavailable Document (afteer)
<img width="843" alt="unavailable-doc-after" src="https://user-images.githubusercontent.com/96776/89827994-43fe0480-db0d-11ea-8234-6c6a5a2daeb3.png">





