### PR TITLE
Revert "Remove duplication on configure block"

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,3 +1,7 @@
 Sidekiq.configure_server do |config|
   config.redis = { url: ENV['REDIS_URL'] || Settings.REDIS_URL }
 end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: ENV['REDIS_URL'] || Settings.REDIS_URL }
+end


### PR DESCRIPTION
Reverts sul-dlss/earthworks#751

Turns out this wasn't duplicated `client/server` but no idea if we need this.