### PR TITLE
Use redis as the cache store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,3 +82,5 @@ gem 'recaptcha', '>= 5.4.1'
 gem 'http'
 gem 'rexml'
 gem 'multi_json'
+
+gem "hiredis", "~> 0.6.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,6 +260,7 @@ GEM
       sprockets (>= 2.0.0)
       tilt (>= 1.2)
     hashdiff (1.0.1)
+    hiredis (0.6.3)
     honeybadger (4.12.1)
     http (5.0.4)
       addressable (~> 2.8)
@@ -518,6 +519,7 @@ DEPENDENCIES
   geo_combine
   geo_monitor (~> 0.7)
   geoblacklight (~> 3.2, >= 3.3.1)
+  hiredis (~> 0.6.3)
   honeybadger
   http
   jbuilder (~> 2.5)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,8 +55,8 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]
 
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  # Use redis as the cache in production.
+  config.cache_store = :redis_cache_store, { url: ENV['REDIS_URL'] || Settings.REDIS_URL }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter     = :sidekiq


### PR DESCRIPTION
- Add hiredis gem for faster redis connections
- Use redis as the cache store in production
