### PR TITLE
Ignore rubocop reformatting commits from git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# .git-blame-ignore-revs
+# rubocop reformat
+e135112dcbb6bd38cb46e489865655974642288a
+# rubocop-performance reformat
+71de73bf052df7df76ae563956c2dc7839c24d2c


### PR DESCRIPTION
If you configure your local git to read from this file, it will
hide changes made by rubocop from the blame view:

`git config blame.ignoreRevsFile .git-blame-ignore-revs`

See https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
