### PR TITLE
Keeps Sidekiq on version 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ gem 'redis', '~> 4.5.1' # 4.6.0 spews deprecation warnings out of sidekiq
 gem 'rsolr'
 gem 'geo_combine'
 gem 'geo_monitor', '~> 0.7', github: 'geoblacklight/geo_monitor'
-gem 'sidekiq'
+gem 'sidekiq', '< 7' # Remain on v6 until Redis is updated to v7 on VMs
 gem 'whenever', require: false
 gem 'bootstrap', '~> 4.0'
 gem 'rack-attack' # For throttle configuration

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -406,8 +406,6 @@ GEM
     recaptcha (5.12.3)
       json
     redis (4.5.1)
-    redis-client (0.10.0)
-      connection_pool
     regexp_parser (2.6.0)
     responders (3.0.1)
       actionpack (>= 5.0)
@@ -477,11 +475,10 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sidekiq (7.0.0)
-      concurrent-ruby (< 2)
-      connection_pool (>= 2.3.0)
-      rack (>= 2.2.4)
-      redis-client (>= 0.9.0)
+    sidekiq (6.5.7)
+      connection_pool (>= 2.2.5)
+      rack (~> 2.0)
+      redis (>= 4.5.0, < 5)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -598,7 +595,7 @@ DEPENDENCIES
   rubocop-rspec
   sassc-rails
   selenium-webdriver (!= 3.13.0)
-  sidekiq
+  sidekiq (< 7)
   simplecov
   solr_wrapper
   sprockets-rails
@@ -610,4 +607,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   2.3.19
+   2.3.20


### PR DESCRIPTION
This will unblock dependency updates and deploys until Redis is updated and we can update sidekiq to version 7. See: https://github.com/sul-dlss/operations-tasks/issues/3210#issuecomment-1302508219