### PR TITLE
Use the builtin cache capability of setup-ruby action

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,15 +18,8 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - uses: actions/cache@v3
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-202206-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-202206-
-    - name: Bundle install
-      run: bundle config path vendor/bundle
-    - name: Install dependencies
+        bundler-cache: true
+    - name: Prepare application
       run: bin/setup
     - name: Run tests
       run: bundle exec rake ci


### PR DESCRIPTION
Hoping that this will bust the cache and fix the dependency issue affecting #956 (which appears to be https://github.com/actions/runner-images/issues/37)