### PR TITLE
Update GeoCombine to v0.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ gem 'newrelic_rpm'
 gem 'twitter-typeahead-rails'
 gem 'blacklight_range_limit', '~> 7.0'
 gem 'redis', '~> 5.0'
-gem 'geo_combine', github: 'OpenGeoMetadata/GeoCombine'
+gem 'geo_combine', '~> 0.8'
 gem 'geo_monitor', '~> 0.7', github: 'geoblacklight/geo_monitor'
 gem 'sidekiq', '~> 7.0'
 gem 'whenever', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,4 @@
 GIT
-  remote: https://github.com/OpenGeoMetadata/GeoCombine.git
-  revision: 6b2fd2b5c5fd5718d22be141faefde30e0df8e48
-  specs:
-    geo_combine (0.7.0)
-      activesupport
-      faraday-net_http_persistent (~> 2.0)
-      git
-      json-schema
-      nokogiri
-      rsolr
-      sanitize
-      thor
-
-GIT
   remote: https://github.com/geoblacklight/geo_monitor.git
   revision: b4cad62d8bdd43c42e5f31f56fe62e666c5f03d2
   specs:
@@ -265,6 +251,15 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    geo_combine (0.8.0)
+      activesupport
+      faraday-net_http_persistent (~> 2.0)
+      git
+      json-schema
+      nokogiri
+      rsolr
+      sanitize
+      thor
     geoblacklight (3.7.0)
       blacklight (~> 7.8)
       coderay
@@ -584,7 +579,7 @@ DEPENDENCIES
   devise-remote-user
   dlss-capistrano
   factory_bot_rails
-  geo_combine!
+  geo_combine (~> 0.8)
   geo_monitor (~> 0.7)!
   geoblacklight (~> 3.7)
   honeybadger


### PR DESCRIPTION
so we can stop pinning it to github branch. once updated upstream in geoblacklight, we no longer need to specify it here