### PR TITLE
Update institutional contact info

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -123,57 +123,90 @@ LEAFLET:
       <<: *opacity_control
 
 INSTITUTIONS:
-  Columbia:
-    department: Columbia University GIS & Statistical Data Resources
-    email: dssc@library.columbia.edu
-  Harvard:
-    department: Harvard Map Collection
-    email: maps@harvard.edu
-  MIT:
-    department: MIT GIS Servcies
-    email: gishelp@mit.edu
-  Tufts:
-    department: GIS at Tufts
-    email: datalab-support@elist.tufts.edu
-  MassGIS:
-    department: MassGIS (Bureau of Geographic Information)
-    email: massgismail@mass.gov
-  Berkeley:
-    department: UC Berkeley Earth Sciences & Map Library
-    email: eart@library.berkeley.edu
-  Minnesota:
-    department: UMN Enterprise GIS Service Center
-    email: gis@umn.edu
-  UCLA:
-    department: Geospatial@UCLA
-    email: geospatial@ucla.edu
-  Iowa:
-    department: UI Libraries Map Collection
-    email: lib-maps@uiowa.edu
-  Princeton:
-    department: Princeton Maps and Geospatial Information Center
-    email: shawatw@princeton.edu
   NYU:
     department: NYU Data Services
     email: data.services@nyu.edu
+  Baruch CUNY:
+    department: Baruch CUNY GIS Lab
+    email: francis.donnelly@baruch.cuny.edu
+  Princeton:
+    department: Princeton Maps and Geospatial Information Center
+    email: shawatw@princeton.edu
+  MIT:
+    department: MIT GIS Servcies
+    email: gishelp@mit.edu
+  Harvard:
+    department: Harvard Map Collection
+    email: maps@harvard.edu
+  Columbia:
+    department: Columbia University GIS & Statistical Data Resources
+    email: dssc@library.columbia.edu
+  Tufts:
+    department: GIS at Tufts
+    email: datalab-support@elist.tufts.edu
   Michigan:
     department: UMich Spatial and Numeric Data Library
     email: nscholtz@umich.edu
   Wisconsin:
     department: Arthur H. Robinson Map Library at University of Wisconsin
     email: jmartindale@wisc.edu
+  Minnesota:
+    department: UMN Enterprise GIS Service Center
+    email: gis@umn.edu
+  Berkeley:
+    department: UC Berkeley Earth Sciences & Map Library
+    email: eart@library.berkeley.edu
+  Cornell:
+    department: Cornell University Library
+    email: kgj2@cornell.edu
+  MassGIS:
+    department: MassGIS (Bureau of Geographic Information)
+    email: massgismail@mass.gov
+  UCLA:
+    department: Geospatial@UCLA
+    email: geospatial@ucla.edu
+  Iowa:
+    department: UI Libraries Map Collection
+    email: lib-maps@uiowa.edu
   Indiana:
     department: Indiana University Research Technologies Division
     email: uitsgis@iu.edu
-  Baruch CUNY:
-    department: Baruch CUNY GIS Lab
-    email: francis.donnelly@baruch.cuny.edu
+  Purdue:
+    department: Purdue University Libraries
+    email: geohelp@purdue.edu
+  Illinois:
+    department: Illinois University Library
+    email: gis@lists.illinois.edu
   Michigan State:
     department: Michigan State University Map Library
     email: atickner@msu.edu
   Maryland:
     department: University of Maryland Libraries’ GIS and Geospatial Services Center
     email: kelleyo@umd.edu
+  Rutgers:
+    department: Rutgers University Libraries
+    email: gis-help@rutgers.edu
+  Penn State:
+    department: Donald W. Hamer Center for Maps and Geospatial Information
+    email: hdr10@psu.edu
+  Ohio State:
+    department: The Ohio State University Libraries
+    email: sadvari.1@osu.edu
+  Chicago:
+    department: University of Chicago Library GIS Data Hub
+    email: mapcollection@lib.uchicago.edu
+  Nebraska:
+    department: University of Nebraska-Lincoln Libraries
+    email: liz.lorang@unl.edu
+  Colorado State:
+    department: Geospatial Centroid at Colorado State University
+    email: gis@colostate.edu
+  Arizona: 
+    department: University of Arizona Library Geospatial Hub
+    email: glenningram@email.arizona.edu
+  Virginia Tech:
+    department: Virginia Tech University Libraries
+    email: gisdata@vt.edu
 
 # Toggle the help text feature that offers users context
 HELP_TEXT:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -156,9 +156,6 @@ INSTITUTIONS:
   NYU:
     department: NYU Data Services
     email: data.services@nyu.edu
-  UVa:
-    department: The Scholars' Lab at UVa
-    email: slabgis@virginia.edu
   Michigan:
     department: UMich Spatial and Numeric Data Library
     email: nscholtz@umich.edu
@@ -220,8 +217,10 @@ OGM_REPOS:
     provenance: Columbia
   edu.tufts:
     provenance: Tufts
-  edu.virginia:
-    provenance: Virginia
+  # No longer publishing to OpenGeoMetadata. See:
+  # https://github.com/OpenGeoMetadata/edu.virginia/issues/13
+  # edu.virginia:
+  #   provenance: Virginia
   edu.umich:
     provenance: Michigan
   edu.wisc:


### PR DESCRIPTION
- Remove settings and contact info for UVa
- Update institutional contact information

this info powers this message when layers aren't available for download or preview:

<img width="839" alt="Screenshot 2023-04-04 at 13 12 09" src="https://user-images.githubusercontent.com/4924494/229909376-48fed040-f15b-4fb1-9b97-8241fc53ba37.png">

this info is a best guess for the newer institutions; I figured that some value is better than nothing (it just shows a blank space in the alert text if there's nothing configured).

see #966 