### PR TITLE
Pin faraday >= 2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,10 +14,6 @@ jobs:
         ruby: ['3.1', '3.2']
     steps:
     - uses: actions/checkout@v3
-    # required to avoid https://github.com/actions/runner-images/issues/37
-    # because faraday depends on patron, which requires curl headers to build
-    - name: Install cURL Headers
-      run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ end
 gem 'blacklight', '~> 7.33'
 gem 'rsolr' # required for Blacklight
 gem "geoblacklight", '~> 3.8'
+gem 'faraday', '~> 2.0'
 gem "devise"
 gem "devise-guests", ">= 0.3.3"
 gem 'devise-remote-user'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -553,6 +553,7 @@ DEPENDENCIES
   devise-remote-user
   dlss-capistrano
   factory_bot_rails
+  faraday (~> 2.0)
   geo_monitor (~> 0.7)!
   geoblacklight (~> 3.8)
   honeybadger

--- a/scripts/geoserver/set_raster_styles.rb
+++ b/scripts/geoserver/set_raster_styles.rb
@@ -18,7 +18,7 @@ raise('GEOSERVER_PASS not provided') unless ENV['GEOSERVER_PASS']
 puts "Updating WMS default style for all raster layers on #{geoserver_url}"
 
 conn = Faraday.new(url: geoserver_url) do |faraday|
-  faraday.basic_auth(ENV.fetch('GEOSERVER_USER', nil), ENV.fetch('GEOSERVER_PASS', nil))
+  faraday.set_basic_auth(ENV.fetch('GEOSERVER_USER', nil), ENV.fetch('GEOSERVER_PASS', nil))
   faraday.adapter :net_http
 end
 

--- a/scripts/geoserver/set_wms_default_style.rb
+++ b/scripts/geoserver/set_wms_default_style.rb
@@ -23,7 +23,7 @@ end
 puts "Updating WMS default style for all vector layers on #{geoserver_url}"
 
 conn = Faraday.new(url: geoserver_url) do |faraday|
-  faraday.basic_auth(ENV.fetch('GEOSERVER_USER', nil), ENV.fetch('GEOSERVER_PASS', nil))
+  faraday.set_basic_auth(ENV.fetch('GEOSERVER_USER', nil), ENV.fetch('GEOSERVER_PASS', nil))
   faraday.adapter :net_http
 end
 

--- a/scripts/geoserver/update_caching.rb
+++ b/scripts/geoserver/update_caching.rb
@@ -15,7 +15,7 @@ raise('GEOSERVER_PASS not provided') unless ENV['GEOSERVER_PASS']
 puts "Updating cache defaults for all layers on #{geoserver_url}"
 
 conn = Faraday.new(url: geoserver_url) do |faraday|
-  faraday.basic_auth(ENV.fetch('GEOSERVER_USER', nil), ENV.fetch('GEOSERVER_PASS', nil))
+  faraday.set_basic_auth(ENV.fetch('GEOSERVER_USER', nil), ENV.fetch('GEOSERVER_PASS', nil))
   faraday.adapter :net_http
 end
 

--- a/scripts/geowebcache/add_gridsets.rb
+++ b/scripts/geowebcache/add_gridsets.rb
@@ -16,7 +16,7 @@ raise('GEOSERVER_PASS not provided') unless ENV['GEOSERVER_PASS']
 puts "Updating gridsets for all layers on #{geoserver_url}"
 
 conn = Faraday.new(url: geoserver_url) do |faraday|
-  faraday.basic_auth(ENV.fetch('GEOSERVER_USER', nil), ENV.fetch('GEOSERVER_PASS', nil))
+  faraday.set_basic_auth(ENV.fetch('GEOSERVER_USER', nil), ENV.fetch('GEOSERVER_PASS', nil))
   faraday.adapter :net_http
 end
 


### PR DESCRIPTION
This removes the downstream dependency on patron, which needs
cURL headers in order to build correctly on Ubuntu machines.

The missing headers cause issues on both GitHub CI runners (https://github.com/actions/runner-images/issues/37)
and our automated deploys
(https://sul-ci-prod.stanford.edu/job/SUL-DLSS/job/earthworks/job/master/56/display/redirect).