### PR TITLE
Remove deployment config for UAT worker box

### DIFF
--- a/config/deploy/uat.rb
+++ b/config/deploy/uat.rb
@@ -4,9 +4,6 @@ set :bundle_without, %w[test development deployment].join(' ')
 
 server 'earthworks-uat-a.stanford.edu', user: 'geostaff', roles: %w[web db app]
 server 'earthworks-uat-b.stanford.edu', user: 'geostaff', roles: %w[web db app]
-server 'earthworks-worker-uat-a.stanford.edu', user: 'geostaff', roles: %w[app background whenevs]
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'
-
-set :sidekiq_roles, :background


### PR DESCRIPTION
The only task that runs on the worker is the CheckLayerJob that
uses GeoMonitor to check layer availability; we don't need to
have both prod and UAT running this job since they're checking
the same set of layers and updating the same solr core.

Ref #942
