### PR TITLE
Prevent multiple worlds being shown on the leaflet map

### DIFF
--- a/app/assets/javascripts/geoblacklight.js
+++ b/app/assets/javascripts/geoblacklight.js
@@ -11,6 +11,7 @@
 GeoBlacklight.Basemaps['OpenStreetMap.HOT'] = L.tileLayer(
     'https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
       maxZoom: 19,
+      noWrap: true,
       attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, Tiles courtesy of <a href="http://hot.openstreetmap.org/" target="_blank">Humanitarian OpenStreetMap Team</a>',
     }
 );


### PR DESCRIPTION
Fixes #911

# before

![Screenshot 2023-04-10 at 13 32 26](https://user-images.githubusercontent.com/4924494/230992775-824a05b5-f967-4ee2-bc78-51ac14c7558c.png)

# after

![Screenshot 2023-04-10 at 13 30 11](https://user-images.githubusercontent.com/4924494/230992718-59773cef-08a2-4288-9792-90847eb37747.png)

