### PR TITLE
Move search icon to a component

### DIFF
--- a/app/components/blacklight/icons/search_component.rb
+++ b/app/components/blacklight/icons/search_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# This was copied out of Blacklight 8.  We can remove this file when we upgrade.
+module Blacklight
+  module Icons
+    # This is the magnifing glass icon for the search button.
+    # You can override the default svg by setting:
+    #   Blacklight::Icons::SearchComponent.svg = '<svg>your SVG here</svg>'
+    class SearchComponent < Blacklight::Icons::IconComponent
+      self.svg = <<~SVG
+        <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="24" height="24" viewBox="0 0 24 24">
+          <path fill="none" d="M0 0h24v24H0V0z"/><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
+        </svg>
+      SVG
+    end
+  end
+end


### PR DESCRIPTION
This removes the dependency on the Redis cache, which seems to fail regularly with EOF