### PR TITLE
Configure redis in a way to avoid timeout errors

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,7 +56,13 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # Use redis as the cache in production.
-  config.cache_store = :redis_cache_store, { url: ENV.fetch('REDIS_URL') { Settings.REDIS_URL } }
+  config.cache_store = :redis_cache_store, {
+    url: ENV.fetch('REDIS_URL') { Settings.REDIS_URL },
+    connect_timeout: 30, # Defaults to 20 seconds
+    read_timeout: 0.2, # Defaults to 1 second
+    write_timeout: 0.2, # Defaults to 1 second
+    reconnect_attempts: 1 # Defaults to 0
+  }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :sidekiq


### PR DESCRIPTION
Taken from https://edgeguides.rubyonrails.org/caching_with_rails.html#activesupport-cache-rediscachestore