### PR TITLE
Decouple CD for stage/UAT and connect to Geoblacklight v4 branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
       }
 
       when {
-        branch 'main'
+        branch 'geobl4'
       }
 
       steps {
@@ -29,7 +29,7 @@ pipeline {
           bundle install --without production
 
           # Deploy it
-          bundle exec cap $DEPLOY_ENVIRONMENT deploy
+          bundle exec cap $DEPLOY_ENVIRONMENT deploy BRANCH=geobl4
           '''
         }
       }
@@ -56,7 +56,7 @@ pipeline {
       }
 
       when {
-        branch 'main'
+        branch 'geobl4'
       }
 
       steps {
@@ -73,7 +73,7 @@ pipeline {
           bundle install --without production
 
           # Deploy it
-          bundle exec cap $DEPLOY_ENVIRONMENT deploy
+          bundle exec cap $DEPLOY_ENVIRONMENT deploy BRANCH=geobl4
           '''
         }
       }


### PR DESCRIPTION
This will allow iterative refinement of the Geoblacklight-4
compatible version of earthworks without needing to pause
dependency updates in production.

It's expected that this work will be finished and reverted by
the start of the Earthworks workcycle on 6/24.

If this is merged, https://github.com/sul-dlss/shared_configs/pull/2194
and https://github.com/sul-dlss/shared_configs/pull/2193 are
also needed to point the app at new compatible solr cores using
the Aardvark schema.
