### PR TITLE
Remove turbolinks properties

### DIFF
--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -44,8 +44,8 @@
 </head>
 <body class="<%= render_body_class %>">
   <nav id="skip-link" role="navigation" aria-label="<%= t('blacklight.skip_links.label') %>">
-    <%= link_to t('blacklight.skip_links.search_field'), '#q', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
-    <%= link_to t('blacklight.skip_links.main_content'), '#main-container', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
+    <%= link_to t('blacklight.skip_links.search_field'), '#q', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbo: 'false' } %>
+    <%= link_to t('blacklight.skip_links.main_content'), '#main-container', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbo: 'false' } %>
     <%= content_for(:skip_links) %>
   </nav>
 


### PR DESCRIPTION
Earthworks doesn't use turbolinks