### PR TITLE
Remove deprecated legacy_connection_handler

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -39,11 +39,6 @@ ActiveSupport.utc_to_local_returns_utc_offset_times = true
 # requests to HTTPS in `ActionDispatch::SSL` middleware.
 Rails.application.config.action_dispatch.ssl_default_redirect_status = 308
 
-# Use new connection handling API. For most applications this won't have any
-# effect. For applications using multiple databases, this new API provides
-# support for granular connection swapping.
-Rails.application.config.active_record.legacy_connection_handling = false
-
 # Make `form_with` generate non-remote forms by default.
 Rails.application.config.action_view.form_with_generates_remote_forms = false
 


### PR DESCRIPTION
This raises ArgumentError because it was deprecated in 7.0 and
removed in 7.1.
