### PR TITLE
Enable sidekiq-web at /queues

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+require 'sidekiq/web'
+
 Rails.application.routes.draw do
   concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new
   mount Blacklight::Engine => '/'
@@ -57,4 +59,9 @@ Rails.application.routes.draw do
       delete 'clear'
     end
   end
+
+  # @note Only admins should be able to access the Sidekiq web UI. This is
+  # accomplished using Apache configuration that is managed by Puppet which
+  # require a user be logged in as a developer to access /queues
+  mount Sidekiq::Web => '/queues'
 end


### PR DESCRIPTION
To help monitor what's going on in the application the sidekiq web interface is mounted at `/queues/`.

Similar to other applications (e.g. H2) access to this route will be blocked upstream in Apache configuration managed by Puppet. See: https://github.com/sul-dlss/puppet/pull/10982 

Closes #369
