### PR TITLE
Remove capistrano-rvm dependency

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -16,7 +16,6 @@ install_plugin Capistrano::SCM::Git
 #   https://github.com/capistrano/bundler
 #   https://github.com/capistrano/rails
 #
-require 'capistrano/rvm'
 require 'capistrano/bundler'
 require 'capistrano/rails'
 require 'capistrano/passenger'

--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,6 @@ end
 
 group :deployment do
   gem 'capistrano'
-  gem 'capistrano-rvm'
   gem 'capistrano-bundler'
   gem 'capistrano-rails'
   gem 'dlss-capistrano'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,9 +132,6 @@ GEM
     capistrano-rails (1.6.3)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
-    capistrano-rvm (0.1.2)
-      capistrano (~> 3.0)
-      sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
     capybara (3.40.0)
       addressable
@@ -601,7 +598,6 @@ DEPENDENCIES
   capistrano-bundler
   capistrano-passenger
   capistrano-rails
-  capistrano-rvm
   capistrano-shared_configs
   capybara
   database_cleaner


### PR DESCRIPTION
The Infra team found a few years ago that this dependency was no longer needed, and it tended to cause problems (none of which I remember at the moment). For now, the way that capistrano-rvm registers its `rvm:hook` task pre-empts the SSH controlmaster stuff in `dlss-capistrano` 5.x and winds up prompting developers for MFA multiple times before hitting an SSH authentication error. Removing the dependency allows the controlmaster setup to occur and restores the ability to deploy.
