### PR TITLE
Update name of solr-core in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,8 @@ Most other commands can be run by prepending `docker compose exec app` to the co
 ### Adding data
 To add a small amount of test records to the Solr index, you can use the `seed` task:
 ```sh
-SOLR_URL=http://127.0.0.1:8983/solr/earthworks bin/rake geoblacklight:solr:seed
+bin/rake geoblacklight:solr:seed
 ```
-
-Note that the Docker solr instance uses a core name of "earthworks", while the default core name configured in the local `blacklight.yml` is called "blacklight-core" (and used in solr-wrapper).  This can cause some confusion.
-
 You can also fetch records from [OpenGeoMetadata](https://github.com/OpenGeoMetadata) using [GeoCombine](https://github.com/OpenGeoMetadata/GeoCombine):
 ```sh
 export OGM_PATH=tmp/opengeometadata     # location to store data

--- a/README.md
+++ b/README.md
@@ -38,8 +38,11 @@ Most other commands can be run by prepending `docker compose exec app` to the co
 ### Adding data
 To add a small amount of test records to the Solr index, you can use the `seed` task:
 ```sh
-bin/rake geoblacklight:solr:seed
+SOLR_URL=http://127.0.0.1:8983/solr/earthworks bin/rake geoblacklight:solr:seed
 ```
+
+Note that the Docker solr instance uses a core name of "earthworks", while the default core name configured in the local `blacklight.yml` is called "blacklight-core" (and used in solr-wrapper).  This can cause some confusion.
+
 You can also fetch records from [OpenGeoMetadata](https://github.com/OpenGeoMetadata) using [GeoCombine](https://github.com/OpenGeoMetadata/GeoCombine):
 ```sh
 export OGM_PATH=tmp/opengeometadata     # location to store data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   app:
     build:
@@ -11,7 +9,7 @@ services:
       REDIS_HOST: cache
       REDIS_PORT: 6379
       DATABASE_URL: postgres://earthworks:earthworks@db:5432/earthworks
-      SOLR_URL: http://index:8983/solr/earthworks
+      SOLR_URL: http://index:8983/solr/blacklight-core
     ports:
       - "3000:3000"
     volumes:
@@ -42,7 +40,7 @@ services:
     entrypoint:
       - docker-entrypoint.sh
       - solr-precreate
-      - earthworks
+      - blacklight-core
       - /solr-setup/conf
 
   cache:


### PR DESCRIPTION
Solr core names differ from solr-wrapper to Docker.  This may reduce some confusion.

This makes them the same so the README instructions are correct.