### PR TITLE
Update sitemap to use the correct ID field

### DIFF
--- a/config/initializers/blacklight_dynamic_sitemap.rb
+++ b/config/initializers/blacklight_dynamic_sitemap.rb
@@ -1,1 +1,1 @@
-BlacklightDynamicSitemap::Engine.config.unique_id_field = 'layer_slug_s'
+BlacklightDynamicSitemap::Engine.config.unique_id_field = 'id'


### PR DESCRIPTION
Document unique ids are just called `id` in Aardvark