### PR TITLE
Add searchworks url to toolbar

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ end
 
 gem 'blacklight', '~> 7.33'
 gem 'rsolr' # required for Blacklight
-gem "geoblacklight", '~> 4.4'
+gem "geoblacklight", '~> 4.4', github: 'geoblacklight/geoblacklight', branch: 'main'
 gem 'faraday', '~> 2.0'
 gem "devise"
 gem "devise-guests", ">= 0.3.3"

--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ end
 
 gem 'blacklight', '~> 7.33'
 gem 'rsolr' # required for Blacklight
-gem "geoblacklight", '~> 4.3.0'
+gem "geoblacklight", '~> 4.4'
 gem 'faraday', '~> 2.0'
 gem "devise"
 gem "devise-guests", ">= 0.3.3"

--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ end
 
 gem 'blacklight', '~> 7.33'
 gem 'rsolr' # required for Blacklight
-gem "geoblacklight", '~> 4.4', github: 'geoblacklight/geoblacklight', branch: 'main'
+gem 'geoblacklight', github: 'geoblacklight/geoblacklight', branch: 'main'
 gem 'faraday', '~> 2.0'
 gem "devise"
 gem "devise-guests", ">= 0.3.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -616,7 +616,7 @@ DEPENDENCIES
   factory_bot_rails (~> 6.2.0)
   faraday (~> 2.0)
   geo_combine (>= 0.9)
-  geoblacklight (~> 4.4)!
+  geoblacklight!
   honeybadger
   http
   jbuilder (~> 2.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,22 @@
+GIT
+  remote: https://github.com/geoblacklight/geoblacklight.git
+  revision: 24aba2e82f4b386e0301d8beebf969727bcf7fb0
+  branch: main
+  specs:
+    geoblacklight (4.4.0)
+      blacklight (~> 7.0)
+      coderay
+      config
+      deprecation
+      faraday (~> 2.0)
+      geo_combine (~> 0.9)
+      handlebars_assets
+      mime-types
+      rails (>= 6.1, < 7.2)
+      rgeo-geojson
+      sprockets-rails (~> 3.0)
+      vite_rails (~> 3.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -225,19 +244,6 @@ GEM
       rsolr
       sanitize
       thor
-    geoblacklight (4.4.0)
-      blacklight (~> 7.0)
-      coderay
-      config
-      deprecation
-      faraday (~> 2.0)
-      geo_combine (~> 0.9)
-      handlebars_assets
-      mime-types
-      rails (>= 6.1, < 7.2)
-      rgeo-geojson
-      sprockets-rails (~> 3.0)
-      vite_rails (~> 3.0)
     git (2.1.1)
       activesupport (>= 5.0)
       addressable (~> 2.8)
@@ -610,7 +616,7 @@ DEPENDENCIES
   factory_bot_rails (~> 6.2.0)
   faraday (~> 2.0)
   geo_combine (>= 0.9)
-  geoblacklight (~> 4.4)
+  geoblacklight (~> 4.4)!
   honeybadger
   http
   jbuilder (~> 2.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,7 +225,7 @@ GEM
       rsolr
       sanitize
       thor
-    geoblacklight (4.3.0)
+    geoblacklight (4.4.0)
       blacklight (~> 7.0)
       coderay
       config
@@ -360,7 +360,7 @@ GEM
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.8.0)
-    rack (3.1.6)
+    rack (3.1.7)
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
     rack-mini-profiler (2.3.4)
@@ -610,7 +610,7 @@ DEPENDENCIES
   factory_bot_rails (~> 6.2.0)
   faraday (~> 2.0)
   geo_combine (>= 0.9)
-  geoblacklight (~> 4.3.0)
+  geoblacklight (~> 4.4)
   honeybadger
   http
   jbuilder (~> 2.5)

--- a/app/components/earthworks/searchworks_url.html.erb
+++ b/app/components/earthworks/searchworks_url.html.erb
@@ -1,0 +1,1 @@
+<%= link_to 'View in Searchworks', document.searchworks_url, id: 'searchworksLink', class: 'nav-link', 'data-turbo': false %>

--- a/app/components/earthworks/searchworks_url.rb
+++ b/app/components/earthworks/searchworks_url.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Earthworks
+  class SearchworksUrl < ViewComponent::Base
+    attr_reader :document
+
+    def initialize(document:, action:, **)
+      @document = document
+      super
+    end
+
+    def render?
+      document.searchworks_url.present?
+    end
+
+    def key
+      'searchworks_url'
+    end
+  end
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -309,15 +309,12 @@ class CatalogController < ApplicationController
     config.add_show_tools_partial(:sms, if: :render_sms_action?, callback: :sms_action, validator: :validate_sms_params)
 
     # Custom tools for GeoBlacklight
-    config.add_show_tools_partial :metadata, if: proc { |_context, _config, options|
-      options[:document] && (Settings.METADATA_SHOWN & options[:document].references.refs.map { |r| r.type.to_s }).any?
-    }
-    config.add_show_tools_partial :arcgis, partial: 'arcgis', if: proc { |_context, _config, options|
-      options[:document] && options[:document].arcgis_urls.present?
-    }
-    config.add_show_tools_partial :data_dictionary, partial: 'data_dictionary', if: proc { |_context, _config, options|
-      options[:document] && options[:document].data_dictionary_download.present?
-    }
+    config.add_show_tools_partial :searchworks_url, component: Earthworks::SearchworksUrl,
+                                                    if: proc { |_context, _config, options|
+                                                          options[:document] &&
+                                                            options[:document].searchworks_url.present?
+                                                        }
+
     config.show.document_actions.delete(:sms)
 
     # Configure basemap provider

--- a/app/helpers/earthworks_geoblacklight_helper.rb
+++ b/app/helpers/earthworks_geoblacklight_helper.rb
@@ -1,9 +1,8 @@
 module EarthworksGeoblacklightHelper
   include GeoblacklightHelper
 
-  def document_available?
-    (@document.public? && @document.available?) ||
-      (@document.same_institution? && user_signed_in? && @document.available?)
+  def document_available?(document = @document)
+    super && document.available?
   end
 
   # Override to render multi-valued description as individual paragraphs

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -28,6 +28,16 @@ class SolrDocument
     fetch(Settings.FIELDS.RESOURCE_CLASS, []) == 'Other'
   end
 
+  # Examine the list of references (in dct_references_s) to find a "schema.org/relatedLink"
+  #  This is going to be the searchworks url if present.
+  #  See https://github.com/sul-dlss/searchworks_traject_indexer/pull/1490
+  #  References are retrieved from the SolrDocument as an array of Geoblacklight::Reference
+  #  where the "reference" attribute is an array of two elements, the first being the type and the second being the url
+  def searchworks_url
+    related_link = references.refs.find { |ref| ref.reference[0] == 'https://schema.org/relatedLink' }
+    related_link.present? ? related_link.reference[1] : nil
+  end
+
   # Email uses the semantic field mappings below to generate the body of an email.
   SolrDocument.use_extension(Blacklight::Document::Email)
 

--- a/spec/features/searchworks_url_spec.rb
+++ b/spec/features/searchworks_url_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe 'Searchworks urls' do
+  context 'when a document has a searchworks url' do
+    it 'shows it' do
+      visit solr_document_path 'stanford-dt131hw5005'
+      expect(page).to have_link 'View in Searchworks'
+    end
+  end
+
+  context 'when a document does not have a searchworks url' do
+    it 'does not shows it' do
+      visit solr_document_path 'stanford-cg357zz0321'
+      expect(page).to have_no_link 'View in Searchworks'
+    end
+  end
+end

--- a/spec/fixtures/solr_documents/stanford-ts545zc6250.json
+++ b/spec/fixtures/solr_documents/stanford-ts545zc6250.json
@@ -11,7 +11,7 @@
   "dct_spatial_sm": ["Palo Alto (Calif.)", "Stanford (Calif.)"],
   "dct_creator_sm": ["Spencer, Eldridge T"],
   "gbl_mdVersion_s": "Aardvark",
-  "dct_references_s": "{\"http://schema.org/url\":\"https://purl.stanford.edu/dt131hw5005\",\"https://oembed.com\":\"https://purl.stanford.edu/embed.json?&hide_title=true&url=https://purl.stanford.edu/dt131hw5005\",\"http://iiif.io/api/presentation#manifest\":\"https://purl.stanford.edu/dt131hw5005/iiif/manifest\"}",
+  "dct_references_s": "{\"https://schema.org/relatedLink\":\"https://searchworks.stanford.edu/view/dt131hw5005\",\"http://schema.org/url\":\"https://purl.stanford.edu/dt131hw5005\",\"https://oembed.com\":\"https://purl.stanford.edu/embed.json?&hide_title=true&url=https://purl.stanford.edu/dt131hw5005\",\"http://iiif.io/api/presentation#manifest\":\"https://purl.stanford.edu/dt131hw5005/iiif/manifest\"}",
   "dcat_bbox": "ENVELOPE(-122.191292, -122.149475, 37.4435369, 37.4063388)",
 	"locn_geometry": "ENVELOPE(-122.191292, -122.149475, 37.4435369, 37.4063388)",
   "id": "stanford-dt131hw5005",


### PR DESCRIPTION
Fixes #310 and follow on from https://github.com/sul-dlss/searchworks_traject_indexer/pull/1490 

If searchworks url is present in solr document, render on the page.

Todo:
- [ ] styling
- [ ] move location on the page?
- [x] use latest geoblacklight (main)?

With link:

http://localhost:3000/catalog/stanford-dt131hw5005

![Screenshot 2024-07-11 at 1 57 28 PM](https://github.com/user-attachments/assets/eb731dd8-1fc5-4640-bafe-a0d4ac186605)
