### PR TITLE
Adding synonym values based on OGP examples

### DIFF
--- a/config/solr_configs/synonyms.txt
+++ b/config/solr_configs/synonyms.txt
@@ -33,117 +33,119 @@ Television, Televisions, TV, TVs
 # Synonym mappings can be used for spelling correction too
 pixima => pixma
 
-# Copied from OGP LCSH synonyms
+# Copied from OGP LCSH synonyms, with duplicates removed from multi-way expansion synonyms 
 Harbors,Pier,Quay,Warf
 
 Hydrocarbons,CNG,Coal,ethanol,gas,gasoline,kerosene,LNG,oil,OPEC,petrol,Petroleum,propane
 
-Walls,Fences,Fortification,fortresses,Gates,Hedges,Seawall,Wall,Walls
+Walls,Fences,Fortification,fortresses,Gates,Hedges,Seawall,Wall
 
-Roads,arteries,automobiles,Avenue,Avenues,beltways,Boulevards,driveways,expressway,expressways,Freeways,highway,highways,intersections,interstate,interstates,lanes,motorways,road,Roadblocks,Roads,Roadways,route,Routes,Speedlimits,Street,Streets,Thoroughfares,Tollbooths,way
+Roads,arteries,automobiles,Avenue,Avenues,beltways,Boulevards,driveways,expressway,expressways,Freeways,highway,highways,intersections,interstate,interstates,lanes,motorways,road,Roadblocks,Roadways,route,Routes,Speedlimits,Street,Streets,Thoroughfares,Tollbooths,way
 
-Schools,academies,College,colleges,colleges/universities,Education,preschool,preschools,school,Schools,universities,university,University/Colleges
+Schools,academies,College,colleges,colleges/universities,Education,preschool,preschools,school,universities,university,University/Colleges
 
 Pedestrians,Curbs,Roads,Footpaths,handicap,Pavements,Pedestrian,sidewalk,Sidewalks,walk,Walking,Walkways
 
-Atmosphere,Air,Atmosphere,climate,Climatology,climatologymeteorology,Cloudiness,Clouds,Evapotrans,Evapotranspiration,haze,humidity,hurricane,Isohyets,Meteorological,Meteorology,Precipitation,Rain,rainfall,Sunshine,temperature,weather,wind
+Atmosphere,Air,climate,Climatology,climatologymeteorology,Cloudiness,Clouds,Evapotrans,Evapotranspiration,haze,humidity,hurricane,Isohyets,Meteorological,Meteorology,Precipitation,Rain,rainfall,Sunshine,temperature,weather,wind
 
-Altitudes,Altitude,Altitudes,Aspect,bathymetry,breaklines,contour,Contours,DEM,depths,DTM,echosounder,elevations,GTOPO30,highpoint,hillshaded,Hypsography,ruggedness,SRTM,terrain,topographic,topography,Topoquads
+Altitudes,Altitude,Aspect,bathymetry,breaklines,contour,Contours,DEM,depths,DTM,echosounder,elevations,GTOPO30,highpoint,hillshaded,Hypsography,ruggedness,SRTM,terrain,topographic,topography,Topoquads
 
 History,ancestry,Historic,historical,History,Memorial,Memorials,Ruins
 
-Industries,chemists,Factories,Buildings,Factory,Buildings,industrial,industries,industry,Iron-works,Manufacture,refineries
+Industries,chemists,Factories,Buildings,Factory,Buildings,industrial,industry,Iron-works,Manufacture,refineries
 
-Water-supply,Drinking,Water-pipes,Water-supply,Waterworks
+Water-supply,Drinking,Water-pipes,Waterworks
 
-watersheds,catchments,hydrology,drainage,hydrology,drainages,hydrology,watershed,hydrology
+watersheds,catchments,hydrology,drainage,drainages,watershed
 
-fishes,anadromous,fish,fisheries,fishing,oncorhynchus,spawn,
+fishes,anadromous,fish,fisheries,fishing,oncorhynchus,spawn
 
-census,ageb,cbsa,census
+census,ageb,cbsa
 
-mountains,hill,hills,mount,mountain,mountains,peak,peaks,ridge,ridgelines,geology,summit
+mountains,hill,hills,mount,mountain,peak,peaks,ridge,ridgelines,geology,summit
 
 bicycles,bicycle,bike
 
-sewerage,drains,manhole,manholes,sewage,sewer,sewerage,sewer-pipe,sewers
+sewerage,drains,manhole,manholes,sewage,sewer,sewer-pipe,sewers
 
-invertebrates,lobsters,mosquitoes,shellfish
+floods,dfirm,finance,flood,flooding,floodplains,watersheds,floodwalls,walls,floodway,nfip,finance,sfha
 
-floods,dfirm,finance,flood,flooding,floodplains,watersheds,floods,floodwalls,walls,floodway,nfip,finance,sfha
+agriculture,agricultural,appellation,commerce,broilers,calves,cattle,chickens,corn,cotton,cranberies,cranberries,cranberry,food,croplands,crops,farm,farming,farms,fertilizers,grazing,herbicide,livestock,orchards,pesticide,plantations,poultry,rice,soybeans,vegetables,viticulture,wheat,wine,wineries
 
-agriculture,agricultural,agriculture,appellation,commerce,broilers,calves,cattle,chickens,corn,cotton,cranberies,food,cranberries,food,cranberry,food,croplands,crops,farm,farming,farms,fertilizers,grazing,herbicide,livestock,orchards,pesticide,plantations,poultry,rice,soybeans,vegetables,viticulture,wheat,wine,food,wineries,food
+hydrology,fwhydrography,hydrographic,hydrography,hydrologic,hydrological,runoff,water-holes
 
-hydrology,fwhydrography,hydrographic,hydrography,hydrologic,hydrological,hydrology,runoff,water-holes
+buildings,building,buildingsr,castles,chimneys,decks,garage,garages,halls,hotels,mansions,porches,rooftop,stories
 
-buildings,building,buildings,buildingsr,castles,chimneys,decks,garage,garages,halls,hotels,mansions,porches,rooftop,stories
+buses,bus,ctran,grta
 
-buses,bus,buses,ctran,grta
+geology,bedrock,erosion,eruptions,eskers,cryosphere,faults,fjords,cryosphere,geomorphology,geoscience,isopach,kettlehole,cryosphere,landslides,lava,lithology,petrology,rocks,volcanoes
 
-geology,bedrock,erosion,eruptions,eskers,cryosphere,faults,fjords,cryosphere,geology,geomorphology,geoscience,isopach,kettlehole,cryosphere,landslides,lava,lithology,petrology,rocks,volcanoes
-
-demography,births,caste,citizenship,deaths,demographic,demographics,demography,ethnicity,family,females,fertility,foreign-born,household,households,illiteracy,schools,language,languages,literacy,males,minorities,mortality,multilingualism,people,population,populations,unemployment,finance
+demography,births,caste,citizenship,deaths,demographic,demographics,ethnicity,family,females,fertility,foreign-born,household,households,illiteracy,schools,language,languages,literacy,males,minorities,mortality,multilingualism,people,population,populations,unemployment,finance
 
 machinery,mechanical,tractors
 
 wetlands,bog
 
-food,burgers,food,hamburgers,restaurants,commerce,supermarket,commerce
+food,burgers,hamburgers,restaurants,commerce,supermarket
 
-coasts,accretion,geology,beach,beaches,breakwater,capes,coast,coastal,coastline,coastlines,coasts,intracoastal,isthmus,isthmuses,nearshore,peninsula,peninsulas,seashore,seashores,shore,shoreline,shorelines,spit
+coasts,accretion,geology,beach,beaches,breakwater,capes,coast,coastal,coastline,coastlines,intracoastal,isthmus,isthmuses,nearshore,peninsula,peninsulas,seashore,seashores,shore,shoreline,shorelines,spit
 
-cryosphere,glaciers,geology,ice,icebergs,nunataks,geology,permafrost,snow,atmosphere,snowsheds
+cryosphere,glaciers,geology,ice,icebergs,nunataks,permafrost,snow,atmosphere,snowsheds
 
-groundwater,aquifers,geology,groundwater,geology,oases,springs,geology
+groundwater,aquifers,geology,geology,oases,springs
 
-youth,child,children,teen,youth
+youth,child,children,teen
 
-plants,eelgrass,gardens,agriculture,plants,seagrass,vegetation
+plants,eelgrass,gardens,agriculture,seagrass,vegetation
 
-earthquakes,earthquakes,geology,magnitude,geology,magnitudes,geology,paleoseismology,geology,seismology,geology
+earthquakes,geology,magnitude,magnitudes,paleoseismology,seismology
 
-recreation,amphitheaters,amphitheatre,aquariums,arenas,athletics,auditoriums,ballfields,campgrounds,casinos,cinemas,clubs,entertainment,exhibitions,golf,hiking,mountaineering,nightclubs,nightlife,opera,play,playground,playgrounds,racetracks,racing,rail-trails,railroads,recreation,regattas,resorts,rinks,speedways,sports,stadium,stadiums,swimming,tennis,theaters,theatres,trail,trails,venues,yachts,ymcas,zoos
+recreation,amphitheaters,amphitheatre,aquariums,arenas,athletics,auditoriums,ballfields,campgrounds,casinos,cinemas,clubs,entertainment,exhibitions,golf,hiking,mountaineering,nightclubs,nightlife,opera,play,playground,playgrounds,racetracks,racing,rail-trails,railroads,regattas,resorts,rinks,speedways,sports,stadium,stadiums,swimming,tennis,theaters,theatres,trail,trails,venues,yachts,ymcas,zoos
 
 photography,landsat,naturalvue,ortho,orthoimagery,ortho-imagery,orthophoto,orthophotography,othophoto
 
-telecommunication,broadcasting,cable,celltowers,telecommunication,telecommunications,telegraph,telephone,telephones,television
+telecommunication,broadcasting,cable,celltowers,telecommunications,telegraph,telephone,telephones,television
 
-railroads,amtrak,fixed-guideway,lirr,metro,metros,monorail,rail,railroad,railroads,rails,railway,railways,railyards,street-railroads,subway,subways,train,trains
+railroads,amtrak,fixed-guideway,lirr,metro,metros,monorail,rail,railroad,rails,railway,railways,railyards,street-railroads,subway,subways,train,trains
 
 airports,aircraft,airfield,airfields,airlines,airplanes,airstrips,enplanements,helicopters,icao,runway,runways
 
-pollution,contaminant,contamination,fouling,atmosphere,nox,atmosphere,ozone,atmosphere,pm10,atmosphere,pollutants,pollution,reclamation,smokestacks,sox,atmosphere
+pollution,contaminant,contamination,fouling,nox,ozone,atmosphere,pm10,pollutants,reclamation,smokestacks,sox
 
-commerce,billboards,businesses,industries,cargo,commerce,commercial,companies,industries,containerization,currencies,customers,employment,freeports,harbors,freight,imports,malls,marketing,markets,occupations,pricing,purchases,rates,retail,revenues,sales,shipping,shops,trade
+commerce,billboards,businesses,industries,cargo,commercial,companies,industries,containerization,currencies,customers,employment,freeports,harbors,freight,imports,malls,marketing,markets,occupations,pricing,purchases,rates,retail,revenues,sales,shipping,shops,trade
 
-rivers,brook,hydrology,brooks,hydrology,creek,hydrology,creeks,hydrology,falls,rapids,river,hydrology,hydrology,riverbeds,riverine,riverline,rivers,hydrology,rivulet,hydrology,runs,stream,hydrology,streambed,streambeds,streamflow,streams,hydrology,streamways,tributary,hydrology,wadies,hydrology,waterfall,waterfalls
+rivers,brook,hydrology,brooks,creek,creeks,falls,rapids,river,riverbeds,riverine,riverline,rivulet,runs,stream,streambed,streambeds,streamflow,streams,streamways,tributary,wadies,waterfall,waterfalls
 
 archaeology,antiquities,relics
 
-finance,atms,bank,banks,finance,income,insurance,tax,taxation,taxes
+finance,atms,bank,banks,income,insurance,tax,taxation,taxes
 
 crises,disaster
 
-# Copied from OGP ISO synonyms
-Pollution,Contaminant,Contamination,Fouling,Atmosphere,NOx,Atmosphere,Ozone,Atmosphere,PM10,Atmosphere,Pollutants,pollution,Reclamation,smokestacks,SOx,Atmosphere
+# Copied from OGP ISO synonyms - with duplicates removed
+
+# Invertebrates line changed to be expansion in a single direction
+Invertebrates => Invertebrates,Lobsters,Mosquitoes,Shellfish
+
+Pollution,Contaminant,Contamination,Fouling,Atmosphere,NOx,Atmosphere,Ozone,Atmosphere,PM10,Atmosphere,Pollutants,Reclamation,smokestacks,SOx,Atmosphere
 
 Older people,elder,elderly,retirement,senior
 
-Buses,Bus,Buses,CTRAN,GRTA
+Buses,Bus,CTRAN,GRTA
 
 Photography,landsat,NaturalVue,ortho,Orthoimagery,ortho-imagery,orthophoto,Orthophotography,Othophoto
 
-Mountains,hill,hills,mount,mountain,Mountains,peak,Peaks,ridge,ridgelines,Geology,summit
+Mountains,hill,hills,mount,mountain,peak,Peaks,ridge,ridgelines,Geology,summit
 
-Water-supply,Drinking,Water-pipes,Water-supply,Waterworks
+Water-supply,Drinking,Water-pipes,Waterworks
 
-Youth,child,children,teen,youth
+Youth,child,children,teen
 
-Coasts,accretion,Geology,beach,Beaches,Breakwater,capes,coast,Coastal,Coastline,coastlines,Coasts,Intracoastal,isthmus,isthmuses,nearshore,peninsula,peninsulas,Seashore,seashores,shore,shoreline,shorelines,spit
+Coasts,accretion,Geology,beach,Beaches,Breakwater,capes,coast,Coastal,Coastline,coastlines,Intracoastal,isthmus,isthmuses,nearshore,peninsula,peninsulas,Seashore,seashores,shore,shoreline,shorelines,spit
 
 Refuse, refuse disposal,garbage,hazmat,Landfill,Landfills,litter,recycling,trash,waste,wastewater
 
-climatologyMeterorologyAtmosphere,Atmosphere,Air,Atmosphere,climate,Climatology,climatologymeteorology,Cloudiness,Clouds,Evapotrans,Evapotranspiration,haze,humidity,hurricane,Isohyets,Meteorological,Meteorology,Precipitation,Rain,rainfall,Sunshine,temperature,weather,wind
+climatologyMeterorologyAtmosphere,Atmosphere,Air,climate,Climatology,climatologymeteorology,Cloudiness,Clouds,Evapotrans,Evapotranspiration,haze,humidity,hurricane,Isohyets,Meteorological,Meteorology,Precipitation,Rain,rainfall,Sunshine,temperature,weather,wind
 
 Census,AGEB,cbsa,Census
 
@@ -151,9 +153,9 @@ Recreation,Amphitheaters,Amphitheatre,aquariums,Arenas,athletics,Auditoriums,bal
 
 Crises,disaster
 
-Agriculture,agricultural,Agriculture,Appellation,Commerce,Broilers,Calves,Cattle,Chickens,Corn,Cotton,Cranberies,Food,Cranberries,Food,cranberry,Food,Croplands,Crops,farm,farming,Farms,fertilizers,grazing,herbicide,Livestock,Orchards,pesticide,Plantations,Poultry,Rice,Soybeans,Vegetables,Viticulture,Wheat,Wine,Food,wineries,Food
+Agriculture,agricultural,Appellation,Commerce,Broilers,Calves,Cattle,Chickens,Corn,Cotton,Cranberies,Food,Cranberries,cranberry,Croplands,Crops,farm,farming,Farms,fertilizers,grazing,herbicide,Livestock,Orchards,pesticide,Plantations,Poultry,Rice,Soybeans,Vegetables,Viticulture,Wheat,Wine,wineries
 
-Geology,bedrock,Erosion,eruptions,Eskers,Cryosphere,faults,fjords,Cryosphere,Geology,Geomorphology,geoscience,isopach,Kettlehole,Cryosphere,Landslides,lava,Lithology,Petrology,Rocks,Volcanoes
+Geology,bedrock,Erosion,eruptions,Eskers,Cryosphere,faults,fjords,Cryosphere,Geomorphology,geoscience,isopach,Kettlehole,Cryosphere,Landslides,lava,Lithology,Petrology,Rocks,Volcanoes
 
 Airports,aircraft,airfield,airfields,airlines,Airplanes,airstrips,enplanements,Helicopters,ICAO,runway,runways
 
@@ -161,13 +163,13 @@ Real property,apartments,Buildings,Assessing,Assessor,cadastral,deeds,Easement,E
 
 "Justice, Administration of",Court,courthouses,Courts,Judicial,Justice,magistrate
 
-Hydrology,FWHYDROGRAPHY,Hydrographic,Hydrography,hydrologic,Hydrological,Hydrology,Runoff,water-holes
+Hydrology,FWHYDROGRAPHY,Hydrographic,Hydrography,hydrologic,Hydrological,Runoff,water-holes
 
-Floods,DFIRM,Finance,Flood,Flooding,Floodplains,Watersheds,Floods,floodwalls,Walls,Floodway,NFIP,Finance,SFHA
+Floods,DFIRM,Finance,Flood,Flooding,Floodplains,Watersheds,floodwalls,Walls,Floodway,NFIP,Finance,SFHA
 
-History,ancestry,Historic,historical,History,Memorial,Memorials,Ruins
+History,ancestry,Historic,historical,Memorial,Memorials,Ruins
 
-Earthquakes,Earthquakes,Geology,Magnitude,Geology,magnitudes,Geology,Paleoseismology,Geology,Seismology,Geology
+Earthquakes,Geology,Magnitude,magnitudes,Paleoseismology,Seismology
 
 utilitiesCommunications,Telecommunication,Broadcasting,cable,celltowers,Telecommunication,Telecommunications,Telegraph,telephone,telephones,television
 
@@ -179,33 +181,34 @@ Public safety,assaults,Emergency,FEMA,Fire,Firebreaks,Firehouses,Fires,Firewall,
 
 Bodies of water,Bayous,channel,channels,Freshwater,gulfs,Coasts,Oshanas,pond,Ponds,sea,Seas,surfacewater
 
-Schools,academies,College,colleges,colleges/universities,Education,preschool,preschools,school,Schools,universities,university,University/Colleges
+Schools,academies,College,colleges,colleges/universities,Education,preschool,preschools,school,universities,university,University/Colleges
 
 Grids (Cartography),Equator,graticule,grid100,grid50,grids,Latitude,Latitude/Longitude,latitudes,Longitude,longitudes,utm
 
-Railroads,Amtrak,fixed-guideway,LIRR,metro,metros,monorail,rail,railroad,Railroads,Rails,railway,railways,Railyards,Street-railroads,subway,Subways,train,Trains
+Railroads,Amtrak,fixed-guideway,LIRR,metro,metros,monorail,rail,railroad,Rails,railway,railways,Railyards,Street-railroads,subway,Subways,train,Trains
 
 Pedestrians,Curbs,Roads,Footpaths,handicap,Pavements,Pedestrian,sidewalk,Sidewalks,walk,Walking,Walkways
 
-structure,Hydraulic structures,aqueduct,aqueducts,Barrages,Breakwaters,Coasts,canal,Canals,Culverts,Dam,Dams,Embankments,Flumes,Gryone,Coasts,Levees,Penstocks,Qanats,sluices,Weir,Weirs
+structure,Hydraulic structures,aqueduct,aqueducts,Barrages,Breakwaters,Coasts,canal,Canals,Culverts,Dam,Dams,Embankments,Flumes,Gryone,Levees,Penstocks,Qanats,sluices,Weir,Weirs
 
-Groundwater,Aquifers,Geology,Groundwater,Geology,Oases,Springs,Geology
+Groundwater,Aquifers,Geology,Oases,Springs
 
-Religious institutions,abbeys,Buddhism,chapels,church,churches,Convents,monasteries,Buildings,Mosques,Buildings,religion,religious,shrines,synagogues,Buildings,Temples,Buildings,Worship
+# This line originally had "buildings" which seems an odd term to make substitutions for, so it was removed here
+Religious institutions,abbeys,Buddhism,chapels,church,churches,Convents,monasteries,Mosques,religion,religious,shrines,synagogues,Temples,Worship
 
-Commerce,Billboards,businesses,Industries,Cargo,commerce,commercial,companies,Industries,Containerization,currencies,customers,employment,freeports,Harbors,freight,imports,malls,marketing,Markets,Occupations,pricing,purchases,rates,retail,revenues,sales,Shipping,shops,trade
+Commerce,Billboards,businesses,Industries,Cargo,commercial,companies,Containerization,currencies,customers,employment,freeports,Harbors,freight,imports,malls,marketing,Markets,Occupations,pricing,purchases,rates,retail,revenues,sales,Shipping,shops,trade
 
 Land use,Cemeteries,cemetery,graveyards,Greenways,grounds,landscaping,Landuse,pave,paved,Pavement,Planimetric,Planning,Plazas,PLSS,rangeland,Redevelopment,Surveying,unpaved,Zoning
 
 Archaeology,Antiquities,Relics
 
-Watersheds,Catchments,Hydrology,Drainage,Hydrology,drainages,Hydrology,Watershed,Watersheds,Hydrology
+Watersheds,Catchments,Hydrology,Drainage,drainages,Watershed,Watersheds
 
 Protected areas,parkland,Parklands,Parks,Parkways,preserves
 
-Demography,births,Caste,Citizenship,deaths,demographic,demographics,Demography,Ethnicity,Family,females,fertility,Foreign-Born,household,households,illiteracy,Schools,language,Languages,Literacy,males,Minorities,mortality,Multilingualism,people,Population,populations,Unemployment,Finance
+Demography,births,Caste,Citizenship,deaths,demographic,demographics,Ethnicity,Family,females,fertility,Foreign-Born,household,households,illiteracy,Schools,language,Languages,Literacy,males,Minorities,mortality,Multilingualism,people,Population,populations,Unemployment,Finance
 
-Public institutions,Jails,Libraries,Buildings,Library,Buildings,museums,penitentiaries,Prison,Prisons
+Public institutions,Jails,Libraries,Buildings,Library,museums,penitentiaries,Prison,Prisons
 
 biota, Ecology & environment,biome,ecological,Ecology,ecoregions,Ecosystem,ecosystems,environmental,evolutionary,habitat,Habitats,reef,Reefs,sustainability,Wildlife,Zoology
 
@@ -213,13 +216,13 @@ Marine mammals,Cetaceans,Dolphins,Porpoises,Whales
 
 Metropolitan areas,metropolitan,urban,Urbanization
 
-Forests,forestry,arboretums,Plants,Evergreen,Plants,forestry,oak,Plants,Pine,Timberline,tree,Plants,Trees,Plants
+Forests,forestry,arboretums,Plants,Evergreen,oak,Pine,Timberline,tree,Trees
 
 Roads,arteries,automobiles,Avenue,Avenues,beltways,Boulevards,driveways,expressway,expressways,Freeways,highway,highways,intersections,interstate,interstates,lanes,motorways,road,Roadblocks,Roads,Roadways,route,Routes,Speedlimits,Street,Streets,Thoroughfares,Tollbooths,way
 
 health,Public health,Clinics,dentists,doctor,doctors,ER,Gonorrhea,HIV,hospital,hospitals,immunization,MDPH,medical,Medicare,medicine,pharmacies,Physicians,polyclinics,quarantine,Sanitation,Syphilis,veterinarians
 
-elevation,Altitudes,Altitude,Altitudes,Aspect,bathymetry,breaklines,contour,Contours,DEM,depths,DTM,echosounder,elevations,GTOPO30,highpoint,hillshaded,Hypsography,ruggedness,SRTM,terrain,topographic,topography,Topoquads
+elevation,Altitudes,Altitude,Aspect,bathymetry,breaklines,contour,Contours,DEM,depths,DTM,echosounder,elevations,GTOPO30,highpoint,hillshaded,Hypsography,ruggedness,SRTM,terrain,topographic,topography,Topoquads
 
 Capitals (Cities),capitals
 
@@ -227,9 +230,9 @@ Wetlands,Bog
 
 "Names, Geographical",gazetteer,Gazetteers,GNS,label,Labels,Lable
 
-Walls,Fences,Fortification,fortresses,Buildings,Gates,Hedges,Seawall,Wall,Walls
+Walls,Fences,Fortification,fortresses,Buildings,Gates,Hedges,Seawall,Wall
 
-Finance,atms,bank,banks,Finance,income,Insurance,Tax,Taxation,Taxes
+Finance,atms,bank,banks,income,Insurance,Tax,Taxation,Taxes
 
 Boats, boating,Boat,Boating,Ferries,ferry,lighthouse,Coasts,lighthouses,Coasts,locks,Marinas,Shipwrecks,waterway,Waterways
 
@@ -237,11 +240,11 @@ intelligenceMilitary,International relations,Armistices,Crises,Army,bioterrorism
 
 boundaries, Administrative,political divisions,administrative,administrativeBoundaries,barrios,border,Borders,boundariesAdministrative,canton,cantons,colony,Counties,countries,county,Countyline,distirct,district,Districts,emirates,lgas,Macroregions,nations,precinct,precincts,Prefectures,province,Provinces,Redistrict,sovereignties,subdistricts,Subdivision,subdivisions,submunicipalities,subregions
 
-Politics, government,commonwealth,Congress,Congressional,constituency,councils,deregulation,election,Elections,Elections--Massachusetts,Electoral,embassies,Governates,Government,legislation,Legislative,Legislators,Legislature,Parliament,political,Politics,Regulation,republic,republics,Senate,States,vote,Voting
+Politics, government,commonwealth,Congress,Congressional,constituency,councils,deregulation,election,Elections,Elections--Massachusetts,Electoral,embassies,Governates,Government,legislation,Legislative,Legislators,Legislature,Parliament,political,Regulation,republic,republics,Senate,States,vote,Voting
 
 Machinery,mechanical,Tractors
 
-Cities,towns,borough,Boroughs,Cities,hamlets,Municipalities,municipality,municipality,municipios,suburbs,Town,Townlands,towns,towns/ville,Villages,ville
+Cities,towns,borough,Boroughs,hamlets,Municipalities,municipality,municipios,suburbs,Town,Townlands,towns/ville,Villages,ville
 
 Hydrocarbons,CNG,Coal,ethanol,gas,gasoline,kerosene,LNG,oil,OPEC,petrol,Petroleum,propane
 
@@ -253,19 +256,17 @@ Harbors,Pier,Quay,Warf
 
 Automobile parking,Parking
 
-Plants,eelgrass,gardens,Agriculture,Plants,seagrass,Vegetation
+Plants,eelgrass,gardens,Agriculture,seagrass,Vegetation
 
-Buildings,building,Buildings,Buildingsr,castles,Chimneys,Decks,garage,garages,halls,Hotels,mansions,office,Porches,rooftop,stories
+Buildings,building,Buildingsr,castles,Chimneys,Decks,garage,garages,halls,Hotels,mansions,office,Porches,rooftop,stories
 
-Industries,chemists,Factories,Buildings,Factory,Buildings,industrial,industries,industry,Iron-works,Manufacture,refineries
+Industries,chemists,Factories,Buildings,Factory,Buildings,industrial,industry,Iron-works,Manufacture,refineries
 
-Mines,mineral resources,Mineral,Geology,minerals,Geology,Mines,mining,prospects,quarries,Quarry,USBM
+Mines,mineral resources,Mineral,Geology,minerals,mining,prospects,quarries,Quarry,USBM
 
 inlandWaters,Rivers,brook,Hydrology,brooks,Hydrology,creek,Hydrology,Creeks,Hydrology,falls,Rapids,river,Hydrology,river/fleuve,Hydrology,riverbeds,Riverine,Riverline,rivers,Hydrology,rivulet,Hydrology,runs,stream,Hydrology,streambed,Streambeds,Streamflow,streams,Hydrology,streamways,tributary,Hydrology,Wadies,Hydrology,Waterfall,Waterfalls
 
-Invertebrates,Lobsters,Mosquitoes,Shellfish
-
-Food,burgers,Food,hamburgers,restaurants,Commerce,supermarket,Commerce
+Food,burgers,hamburgers,restaurants,Commerce,supermarket,Commerce
 
 Cryosphere,Glaciers,Geology,Ice,Icebergs,Nunataks,Geology,permafrost,Snow,Atmosphere,Snowsheds
 
@@ -275,11 +276,11 @@ Postal service,address,Roads,addresses,Roads,CEP8,mail,PLZgrenzen,postal,postcod
 
 Human settlements,condominiums,Dormitories,Dwellings,homelessness,homes,Huts,inhabitancy,Neighborhood,Neighborhoods,residences,Settlement,settlements,squatters
 
-Sewerage,drains,manhole,Manholes,sewage,Sewer,Sewerage,Sewer-pipe,Sewers
+Sewerage,drains,manhole,Manholes,sewage,Sewer,Sewer-pipe,Sewers
 
 Fishes,Anadromous,Fish,Fisheries,Fishing,Oncorhynchus,Spawn,Wildlife/Fisheries
 
-Territories, possessions,Annexation,Annexations,territories,territory
+Territories, possessions,Annexation,Annexations,territory
 
 Electric power systems,biodiesel,Electric,electricity,energy,fuel,Fuels,Generators,hydrogen,megawatt-hours,MWh,Power-plants,Substation,substations,Windmills
 

--- a/config/solr_configs/synonyms.txt
+++ b/config/solr_configs/synonyms.txt
@@ -18,6 +18,10 @@ ccc => cccc1,cccc2
 a\=>a => b\=>b
 a\,a => b\,b
 fooaaa,baraaa,bazaaa
+#The OGP file also includes these mappings
+aaafoo => aaabar
+bbbfoo => bbbfoo bbbbar
+cccfoo => cccbar cccbaz
 
 # Some synonym groups specific to this example
 GB,gib,gigabyte,gigabytes
@@ -28,3 +32,358 @@ Television, Televisions, TV, TVs
 
 # Synonym mappings can be used for spelling correction too
 pixima => pixma
+
+# Copied from OGP LCSH synonyms
+Harbors,Pier,Quay,Warf
+
+Hydrocarbons,CNG,Coal,ethanol,gas,gasoline,kerosene,LNG,oil,OPEC,petrol,Petroleum,propane
+
+Walls,Fences,Fortification,fortresses,Gates,Hedges,Seawall,Wall,Walls
+
+Roads,arteries,automobiles,Avenue,Avenues,beltways,Boulevards,driveways,expressway,expressways,Freeways,highway,highways,intersections,interstate,interstates,lanes,motorways,road,Roadblocks,Roads,Roadways,route,Routes,Speedlimits,Street,Streets,Thoroughfares,Tollbooths,way
+
+Schools,academies,College,colleges,colleges/universities,Education,preschool,preschools,school,Schools,universities,university,University/Colleges
+
+Pedestrians,Curbs,Roads,Footpaths,handicap,Pavements,Pedestrian,sidewalk,Sidewalks,walk,Walking,Walkways
+
+Atmosphere,Air,Atmosphere,climate,Climatology,climatologymeteorology,Cloudiness,Clouds,Evapotrans,Evapotranspiration,haze,humidity,hurricane,Isohyets,Meteorological,Meteorology,Precipitation,Rain,rainfall,Sunshine,temperature,weather,wind
+
+Altitudes,Altitude,Altitudes,Aspect,bathymetry,breaklines,contour,Contours,DEM,depths,DTM,echosounder,elevations,GTOPO30,highpoint,hillshaded,Hypsography,ruggedness,SRTM,terrain,topographic,topography,Topoquads
+
+History,ancestry,Historic,historical,History,Memorial,Memorials,Ruins
+
+Industries,chemists,Factories,Buildings,Factory,Buildings,industrial,industries,industry,Iron-works,Manufacture,refineries
+
+Water-supply,Drinking,Water-pipes,Water-supply,Waterworks
+
+watersheds,catchments,hydrology,drainage,hydrology,drainages,hydrology,watershed,hydrology
+
+fishes,anadromous,fish,fisheries,fishing,oncorhynchus,spawn,
+
+census,ageb,cbsa,census
+
+mountains,hill,hills,mount,mountain,mountains,peak,peaks,ridge,ridgelines,geology,summit
+
+bicycles,bicycle,bike
+
+sewerage,drains,manhole,manholes,sewage,sewer,sewerage,sewer-pipe,sewers
+
+invertebrates,lobsters,mosquitoes,shellfish
+
+floods,dfirm,finance,flood,flooding,floodplains,watersheds,floods,floodwalls,walls,floodway,nfip,finance,sfha
+
+agriculture,agricultural,agriculture,appellation,commerce,broilers,calves,cattle,chickens,corn,cotton,cranberies,food,cranberries,food,cranberry,food,croplands,crops,farm,farming,farms,fertilizers,grazing,herbicide,livestock,orchards,pesticide,plantations,poultry,rice,soybeans,vegetables,viticulture,wheat,wine,food,wineries,food
+
+hydrology,fwhydrography,hydrographic,hydrography,hydrologic,hydrological,hydrology,runoff,water-holes
+
+buildings,building,buildings,buildingsr,castles,chimneys,decks,garage,garages,halls,hotels,mansions,porches,rooftop,stories
+
+buses,bus,buses,ctran,grta
+
+geology,bedrock,erosion,eruptions,eskers,cryosphere,faults,fjords,cryosphere,geology,geomorphology,geoscience,isopach,kettlehole,cryosphere,landslides,lava,lithology,petrology,rocks,volcanoes
+
+demography,births,caste,citizenship,deaths,demographic,demographics,demography,ethnicity,family,females,fertility,foreign-born,household,households,illiteracy,schools,language,languages,literacy,males,minorities,mortality,multilingualism,people,population,populations,unemployment,finance
+
+machinery,mechanical,tractors
+
+wetlands,bog
+
+food,burgers,food,hamburgers,restaurants,commerce,supermarket,commerce
+
+coasts,accretion,geology,beach,beaches,breakwater,capes,coast,coastal,coastline,coastlines,coasts,intracoastal,isthmus,isthmuses,nearshore,peninsula,peninsulas,seashore,seashores,shore,shoreline,shorelines,spit
+
+cryosphere,glaciers,geology,ice,icebergs,nunataks,geology,permafrost,snow,atmosphere,snowsheds
+
+groundwater,aquifers,geology,groundwater,geology,oases,springs,geology
+
+youth,child,children,teen,youth
+
+plants,eelgrass,gardens,agriculture,plants,seagrass,vegetation
+
+earthquakes,earthquakes,geology,magnitude,geology,magnitudes,geology,paleoseismology,geology,seismology,geology
+
+recreation,amphitheaters,amphitheatre,aquariums,arenas,athletics,auditoriums,ballfields,campgrounds,casinos,cinemas,clubs,entertainment,exhibitions,golf,hiking,mountaineering,nightclubs,nightlife,opera,play,playground,playgrounds,racetracks,racing,rail-trails,railroads,recreation,regattas,resorts,rinks,speedways,sports,stadium,stadiums,swimming,tennis,theaters,theatres,trail,trails,venues,yachts,ymcas,zoos
+
+photography,landsat,naturalvue,ortho,orthoimagery,ortho-imagery,orthophoto,orthophotography,othophoto
+
+telecommunication,broadcasting,cable,celltowers,telecommunication,telecommunications,telegraph,telephone,telephones,television
+
+railroads,amtrak,fixed-guideway,lirr,metro,metros,monorail,rail,railroad,railroads,rails,railway,railways,railyards,street-railroads,subway,subways,train,trains
+
+airports,aircraft,airfield,airfields,airlines,airplanes,airstrips,enplanements,helicopters,icao,runway,runways
+
+pollution,contaminant,contamination,fouling,atmosphere,nox,atmosphere,ozone,atmosphere,pm10,atmosphere,pollutants,pollution,reclamation,smokestacks,sox,atmosphere
+
+commerce,billboards,businesses,industries,cargo,commerce,commercial,companies,industries,containerization,currencies,customers,employment,freeports,harbors,freight,imports,malls,marketing,markets,occupations,pricing,purchases,rates,retail,revenues,sales,shipping,shops,trade
+
+rivers,brook,hydrology,brooks,hydrology,creek,hydrology,creeks,hydrology,falls,rapids,river,hydrology,hydrology,riverbeds,riverine,riverline,rivers,hydrology,rivulet,hydrology,runs,stream,hydrology,streambed,streambeds,streamflow,streams,hydrology,streamways,tributary,hydrology,wadies,hydrology,waterfall,waterfalls
+
+archaeology,antiquities,relics
+
+finance,atms,bank,banks,finance,income,insurance,tax,taxation,taxes
+
+crises,disaster
+
+# Copied from OGP ISO synonyms
+Pollution,Contaminant,Contamination,Fouling,Atmosphere,NOx,Atmosphere,Ozone,Atmosphere,PM10,Atmosphere,Pollutants,pollution,Reclamation,smokestacks,SOx,Atmosphere
+
+Older people,elder,elderly,retirement,senior
+
+Buses,Bus,Buses,CTRAN,GRTA
+
+Photography,landsat,NaturalVue,ortho,Orthoimagery,ortho-imagery,orthophoto,Orthophotography,Othophoto
+
+Mountains,hill,hills,mount,mountain,Mountains,peak,Peaks,ridge,ridgelines,Geology,summit
+
+Water-supply,Drinking,Water-pipes,Water-supply,Waterworks
+
+Youth,child,children,teen,youth
+
+Coasts,accretion,Geology,beach,Beaches,Breakwater,capes,coast,Coastal,Coastline,coastlines,Coasts,Intracoastal,isthmus,isthmuses,nearshore,peninsula,peninsulas,Seashore,seashores,shore,shoreline,shorelines,spit
+
+Refuse, refuse disposal,garbage,hazmat,Landfill,Landfills,litter,recycling,trash,waste,wastewater
+
+climatologyMeterorologyAtmosphere,Atmosphere,Air,Atmosphere,climate,Climatology,climatologymeteorology,Cloudiness,Clouds,Evapotrans,Evapotranspiration,haze,humidity,hurricane,Isohyets,Meteorological,Meteorology,Precipitation,Rain,rainfall,Sunshine,temperature,weather,wind
+
+Census,AGEB,cbsa,Census
+
+Recreation,Amphitheaters,Amphitheatre,aquariums,Arenas,athletics,Auditoriums,ballfields,Campgrounds,casinos,cinemas,Clubs,entertainment,Exhibitions,golf,Hiking,Mountaineering,"Museums,",Nightclubs,nightlife,opera,play,Playground,Playgrounds,Racetracks,Racing,Rail-trails,Railroads,recreation,Regattas,resorts,rinks,speedways,Sports,Stadium,Stadiums,swimming,tennis,theaters,theatres,trail,Trails,venues,yachts,YMCAs,Zoos
+
+Crises,disaster
+
+Agriculture,agricultural,Agriculture,Appellation,Commerce,Broilers,Calves,Cattle,Chickens,Corn,Cotton,Cranberies,Food,Cranberries,Food,cranberry,Food,Croplands,Crops,farm,farming,Farms,fertilizers,grazing,herbicide,Livestock,Orchards,pesticide,Plantations,Poultry,Rice,Soybeans,Vegetables,Viticulture,Wheat,Wine,Food,wineries,Food
+
+Geology,bedrock,Erosion,eruptions,Eskers,Cryosphere,faults,fjords,Cryosphere,Geology,Geomorphology,geoscience,isopach,Kettlehole,Cryosphere,Landslides,lava,Lithology,Petrology,Rocks,Volcanoes
+
+Airports,aircraft,airfield,airfields,airlines,Airplanes,airstrips,enplanements,Helicopters,ICAO,runway,runways
+
+Real property,apartments,Buildings,Assessing,Assessor,cadastral,deeds,Easement,Easements,encumbrance,erven,Housing,Landowners,leasehold,leases,lot,Lots,parcel,Parcels,Property,servitude
+
+"Justice, Administration of",Court,courthouses,Courts,Judicial,Justice,magistrate
+
+Hydrology,FWHYDROGRAPHY,Hydrographic,Hydrography,hydrologic,Hydrological,Hydrology,Runoff,water-holes
+
+Floods,DFIRM,Finance,Flood,Flooding,Floodplains,Watersheds,Floods,floodwalls,Walls,Floodway,NFIP,Finance,SFHA
+
+History,ancestry,Historic,historical,History,Memorial,Memorials,Ruins
+
+Earthquakes,Earthquakes,Geology,Magnitude,Geology,magnitudes,Geology,Paleoseismology,Geology,Seismology,Geology
+
+utilitiesCommunications,Telecommunication,Broadcasting,cable,celltowers,Telecommunication,Telecommunications,Telegraph,telephone,telephones,television
+
+environment,Environmental protection,Conservation,EPA,NHESP
+
+transportation, Terminals (Transportation),hubs,seaports,terminals
+
+Public safety,assaults,Emergency,FEMA,Fire,Firebreaks,Firehouses,Fires,Firewall,firewalls,Fuelbreaks,Hazard,Hazards,Hydrants,Larceny,shelter,shelters,signals,Signs,Streetlights,Traffic,Wildfire
+
+Bodies of water,Bayous,channel,channels,Freshwater,gulfs,Coasts,Oshanas,pond,Ponds,sea,Seas,surfacewater
+
+Schools,academies,College,colleges,colleges/universities,Education,preschool,preschools,school,Schools,universities,university,University/Colleges
+
+Grids (Cartography),Equator,graticule,grid100,grid50,grids,Latitude,Latitude/Longitude,latitudes,Longitude,longitudes,utm
+
+Railroads,Amtrak,fixed-guideway,LIRR,metro,metros,monorail,rail,railroad,Railroads,Rails,railway,railways,Railyards,Street-railroads,subway,Subways,train,Trains
+
+Pedestrians,Curbs,Roads,Footpaths,handicap,Pavements,Pedestrian,sidewalk,Sidewalks,walk,Walking,Walkways
+
+structure,Hydraulic structures,aqueduct,aqueducts,Barrages,Breakwaters,Coasts,canal,Canals,Culverts,Dam,Dams,Embankments,Flumes,Gryone,Coasts,Levees,Penstocks,Qanats,sluices,Weir,Weirs
+
+Groundwater,Aquifers,Geology,Groundwater,Geology,Oases,Springs,Geology
+
+Religious institutions,abbeys,Buddhism,chapels,church,churches,Convents,monasteries,Buildings,Mosques,Buildings,religion,religious,shrines,synagogues,Buildings,Temples,Buildings,Worship
+
+Commerce,Billboards,businesses,Industries,Cargo,commerce,commercial,companies,Industries,Containerization,currencies,customers,employment,freeports,Harbors,freight,imports,malls,marketing,Markets,Occupations,pricing,purchases,rates,retail,revenues,sales,Shipping,shops,trade
+
+Land use,Cemeteries,cemetery,graveyards,Greenways,grounds,landscaping,Landuse,pave,paved,Pavement,Planimetric,Planning,Plazas,PLSS,rangeland,Redevelopment,Surveying,unpaved,Zoning
+
+Archaeology,Antiquities,Relics
+
+Watersheds,Catchments,Hydrology,Drainage,Hydrology,drainages,Hydrology,Watershed,Watersheds,Hydrology
+
+Protected areas,parkland,Parklands,Parks,Parkways,preserves
+
+Demography,births,Caste,Citizenship,deaths,demographic,demographics,Demography,Ethnicity,Family,females,fertility,Foreign-Born,household,households,illiteracy,Schools,language,Languages,Literacy,males,Minorities,mortality,Multilingualism,people,Population,populations,Unemployment,Finance
+
+Public institutions,Jails,Libraries,Buildings,Library,Buildings,museums,penitentiaries,Prison,Prisons
+
+biota, Ecology & environment,biome,ecological,Ecology,ecoregions,Ecosystem,ecosystems,environmental,evolutionary,habitat,Habitats,reef,Reefs,sustainability,Wildlife,Zoology
+
+Marine mammals,Cetaceans,Dolphins,Porpoises,Whales
+
+Metropolitan areas,metropolitan,urban,Urbanization
+
+Forests,forestry,arboretums,Plants,Evergreen,Plants,forestry,oak,Plants,Pine,Timberline,tree,Plants,Trees,Plants
+
+Roads,arteries,automobiles,Avenue,Avenues,beltways,Boulevards,driveways,expressway,expressways,Freeways,highway,highways,intersections,interstate,interstates,lanes,motorways,road,Roadblocks,Roads,Roadways,route,Routes,Speedlimits,Street,Streets,Thoroughfares,Tollbooths,way
+
+health,Public health,Clinics,dentists,doctor,doctors,ER,Gonorrhea,HIV,hospital,hospitals,immunization,MDPH,medical,Medicare,medicine,pharmacies,Physicians,polyclinics,quarantine,Sanitation,Syphilis,veterinarians
+
+elevation,Altitudes,Altitude,Altitudes,Aspect,bathymetry,breaklines,contour,Contours,DEM,depths,DTM,echosounder,elevations,GTOPO30,highpoint,hillshaded,Hypsography,ruggedness,SRTM,terrain,topographic,topography,Topoquads
+
+Capitals (Cities),capitals
+
+Wetlands,Bog
+
+"Names, Geographical",gazetteer,Gazetteers,GNS,label,Labels,Lable
+
+Walls,Fences,Fortification,fortresses,Buildings,Gates,Hedges,Seawall,Wall,Walls
+
+Finance,atms,bank,banks,Finance,income,Insurance,Tax,Taxation,Taxes
+
+Boats, boating,Boat,Boating,Ferries,ferry,lighthouse,Coasts,lighthouses,Coasts,locks,Marinas,Shipwrecks,waterway,Waterways
+
+intelligenceMilitary,International relations,Armistices,Crises,Army,bioterrorism,Crises,CIA,Installation,Installations,Military,Navy
+
+boundaries, Administrative,political divisions,administrative,administrativeBoundaries,barrios,border,Borders,boundariesAdministrative,canton,cantons,colony,Counties,countries,county,Countyline,distirct,district,Districts,emirates,lgas,Macroregions,nations,precinct,precincts,Prefectures,province,Provinces,Redistrict,sovereignties,subdistricts,Subdivision,subdivisions,submunicipalities,subregions
+
+Politics, government,commonwealth,Congress,Congressional,constituency,councils,deregulation,election,Elections,Elections--Massachusetts,Electoral,embassies,Governates,Government,legislation,Legislative,Legislators,Legislature,Parliament,political,Politics,Regulation,republic,republics,Senate,States,vote,Voting
+
+Machinery,mechanical,Tractors
+
+Cities,towns,borough,Boroughs,Cities,hamlets,Municipalities,municipality,municipality,municipios,suburbs,Town,Townlands,towns,towns/ville,Villages,ville
+
+Hydrocarbons,CNG,Coal,ethanol,gas,gasoline,kerosene,LNG,oil,OPEC,petrol,Petroleum,propane
+
+Indigenous peoples,tribes
+
+Land cover,brush,Plants,Caves,Cliffs,continents,coves,Desert,Atmosphere,Deserts,earthCover,Fields,Gorges,Grassland,Plants,Grasslands,Plants,Heathlands,Plants,island,Islands,Landcover,Landform,Landforms,Landscape,Landscapes,meadow,palisade,plain,plains,Prairies,tundra,Tundras,Wilderness
+
+Harbors,Pier,Quay,Warf
+
+Automobile parking,Parking
+
+Plants,eelgrass,gardens,Agriculture,Plants,seagrass,Vegetation
+
+Buildings,building,Buildings,Buildingsr,castles,Chimneys,Decks,garage,garages,halls,Hotels,mansions,office,Porches,rooftop,stories
+
+Industries,chemists,Factories,Buildings,Factory,Buildings,industrial,industries,industry,Iron-works,Manufacture,refineries
+
+Mines,mineral resources,Mineral,Geology,minerals,Geology,Mines,mining,prospects,quarries,Quarry,USBM
+
+inlandWaters,Rivers,brook,Hydrology,brooks,Hydrology,creek,Hydrology,Creeks,Hydrology,falls,Rapids,river,Hydrology,river/fleuve,Hydrology,riverbeds,Riverine,Riverline,rivers,Hydrology,rivulet,Hydrology,runs,stream,Hydrology,streambed,Streambeds,Streamflow,streams,Hydrology,streamways,tributary,Hydrology,Wadies,Hydrology,Waterfall,Waterfalls
+
+Invertebrates,Lobsters,Mosquitoes,Shellfish
+
+Food,burgers,Food,hamburgers,restaurants,Commerce,supermarket,Commerce
+
+Cryosphere,Glaciers,Geology,Ice,Icebergs,Nunataks,Geology,permafrost,Snow,Atmosphere,Snowsheds
+
+Bicycles,Bicycle,Bike
+
+Postal service,address,Roads,addresses,Roads,CEP8,mail,PLZgrenzen,postal,postcodes,zip,zip+4,zipcode,zipcodes
+
+Human settlements,condominiums,Dormitories,Dwellings,homelessness,homes,Huts,inhabitancy,Neighborhood,Neighborhoods,residences,Settlement,settlements,squatters
+
+Sewerage,drains,manhole,Manholes,sewage,Sewer,Sewerage,Sewer-pipe,Sewers
+
+Fishes,Anadromous,Fish,Fisheries,Fishing,Oncorhynchus,Spawn,Wildlife/Fisheries
+
+Territories, possessions,Annexation,Annexations,territories,territory
+
+Electric power systems,biodiesel,Electric,electricity,energy,fuel,Fuels,Generators,hydrogen,megawatt-hours,MWh,Power-plants,Substation,substations,Windmills
+
+# Copied from OGP placename synonyms
+Alabama ,AL ,Ala ,Ala 
+
+Alaska ,AK ,Alaska ,Alas
+
+Arizona ,AZ ,Ariz ,Ariz 
+
+Arkansas ,AR ,Ark ,Ark 
+
+California ,CA ,Calif ,Calif 
+
+Colorado ,CO ,Colo ,Colo 
+
+Connecticut ,CT ,Conn ,Conn 
+
+Delaware ,DE ,Del ,Del 
+
+District of Columbia ,DC ,DC ,DC 
+
+Florida ,FL ,Fla ,Fla 
+
+Georgia ,GA ,Ga ,Ga 
+
+Hawaii ,HI ,Hawaii ,Hawaii 
+
+Idaho ,ID ,Idaho ,Idaho 
+
+Illinois ,IL ,Ill ,Ill 
+
+Indiana ,IN ,Ind ,Ind 
+
+Iowa ,IA ,Iowa ,Iowa 
+
+Kansas ,KS ,Kans ,Kan 
+
+Kentucky ,KY ,Ky ,Ky 
+
+Louisiana ,LA ,La ,La 
+
+Maine ,ME ,Maine ,Maine 
+
+Maryland ,MD ,Md ,Md 
+
+Massachusetts ,MA ,Mass ,Mass 
+
+Michigan ,MI ,Mich ,Mich 
+
+Minnesota ,MN ,Minn ,Minn 
+
+Mississippi ,MS ,Miss ,Miss 
+
+Missouri ,MO ,Mo ,Mo 
+
+Montana ,MT ,Mont ,Mont 
+
+Nebraska ,NE ,Nebr ,Neb 
+
+Nevada ,NV ,Nev ,Nev 
+
+New Hampshire ,NH ,NH ,NH 
+
+New Jersey ,NJ ,NJ ,NJ 
+
+New Mexico ,NM ,N Mex ,NM 
+
+New York ,NY ,NY ,NY 
+
+North Carolina ,NC ,NC ,N Car
+
+North Dakota ,ND ,N Dak ,ND 
+
+Ohio ,OH ,Ohio ,Ohio 
+
+Oklahoma ,OK ,Okla ,Okla 
+
+Oregon ,OR ,Oreg ,Ore 
+
+Pennsylvania ,PA ,Pa ,Penn
+
+Rhode Island ,RI ,RI ,RI 
+
+South Carolina ,SC ,SC ,S Car
+
+South Dakota ,SD ,S Dak ,SD 
+
+Tennessee ,TN ,Tenn ,Tenn 
+
+Texas ,TX ,Tex ,Texas 
+
+Utah ,UT ,Utah ,Utah 
+
+Vermont ,VT ,Vt ,Vt 
+
+Virginia ,VA ,Va ,Virg 
+
+Washington ,WA ,Wash ,Wash 
+
+West Virginia ,WV ,W Va ,WVa 
+
+Wisconsin ,WI ,Wis ,Wisc
+
+Wyoming ,WY ,Wyo ,Wyo 
+
+Puerto Rico,PR,PR,


### PR DESCRIPTION
Addresses #41 .
**What this pull request does:**
Copies the additional synonym lines from the following files under the originally referenced OpenGeoPortal configuration: 
https://github.com/OpenGeoportal/ogpSolrConfig/tree/master/ogpSolrConfig/SolrConfig

These include synonyms for LCSH terms (e.g. mapping "mountains" and "peaks" to each other so that any query for mountains would include both mountains and peaks in the query after synonyms have been applied), synonyms for ISO  (e.g. mapping "History" and "ancestry" to each other), and State names (e.g. mapping Wyoming and "WY " - with a trailing space - to each other). 

An additional pull request will apply these changes to sul-solr-configs starting with stage. 

**Using synonyms in Solr**
One of the LCSH mappings is between mountains and peaks (and several other words). 

There is a Solr record "HOV Lanes, San Francisco Bay Area, 2002" which contains the word "peak" but not "mountains" in its fields. 

On my local machine, I have an example of an EarthWorks solr index with this document which uses the current schema/solrconfig and another example which uses a version with the updated synonyms file. 

Using the non-updated EarthWorks solr, when querying for the word "mountains", we do not see this document in the result.  The analysis page also shows no synonyms are in play. 

Using the updated EarthWorks solr, when querying for the word "mountains", we do see this document in the results.  The analysis page also shows the synonyms for "mountains" is in play. 

<img width="1653" alt="Screenshot 2024-07-11 at 3 17 13 PM" src="https://github.com/user-attachments/assets/77fa8ae1-d319-4141-b7b3-65949dbc76f5">

Part of the analysis page is below (which shows the other synonyms in the list for "mountains"):
<img width="1517" alt="Screenshot 2024-07-11 at 3 18 36 PM" src="https://github.com/user-attachments/assets/06f52ef7-e5e9-4a75-bace-a6038b3b5669">



**Additional context from the OGP side:**

OpenGeoPortal had separate fields for themes, place names, and layer display names (in addition to others).  They also had versions of these fields which also used field types that relied on the appropriate synonym file e.g. a theme field that uses the LCSH synonyms.  They could then utilize different boosting for these fields: e.g. https://github.com/OpenGeoportal/OGP2/blob/master/geoportal_1/src/main/webapp/resources/javascript/lib/solr.js#L318 .  

In our case, we are adding all the synonym files directly for the "text_en" field type i.e. the "text" field that is used as part of regular queries (for reference, see the /select handler and qf and pf which both employ the text field). 