### PR TITLE
rake task and cron job for clearing stale downloads

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -6,9 +6,7 @@ OkComputer::Registry.register 'solr',
   OkComputer::HttpCheck.new(Blacklight.default_index.connection.uri.to_s.sub(%r{/$}, '') + '/admin/ping')
 
 OkComputer::Registry.register 'downloads-cache',
-  OkComputer::DirectoryCheck.new(
-    Settings.DOWNLOAD_PATH || (Rails.root + 'tmp/cache/downloads').to_s, true
-  )
+  OkComputer::DirectoryCheck.new(Settings.DOWNLOAD_PATH, true)
 
 OkComputer::Registry.register 'redis',
   OkComputer::RedisCheck.new(url: ENV.fetch('REDIS_URL') { Settings.REDIS_URL })

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -39,6 +39,10 @@ every '0 3 * * *', roles: %i[app] do # daily at 3 am
   rake 'earthworks:clear_rack_attack_cache'
 end
 
+every 1.day, at: '1:04 am', roles: %i[whenevs] do
+  rake 'rake earthworks:clear_download_cache_stale_files'
+end
+
 every 1.day, at: '3:04 am', roles: %i[whenevs] do
   rake 'rake earthworks:prune_old_guest_user_data[3]'
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,7 +2,7 @@
 ARCGIS_BASE_URL: "https://www.arcgis.com/home/webmap/viewer.html"
 
 # DOWNLOAD_PATH is set in production but defaults to this tmp dir when not set
-# DOWNLOAD_PATH: './tmp/cache/downloads'
+DOWNLOAD_PATH: './tmp/cache/downloads'
 download_cache_expiry_time_days: 14 # the number of days since a download was last accessed before it is removed from the cache
 
 # Main Solr geometry field used for spatial search and bounding box. Should be type 'rpt'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,6 +3,7 @@ ARCGIS_BASE_URL: "https://www.arcgis.com/home/webmap/viewer.html"
 
 # DOWNLOAD_PATH is set in production but defaults to this tmp dir when not set
 # DOWNLOAD_PATH: './tmp/cache/downloads'
+download_cache_expiry_time_days: 14 # the number of days since a download was last accessed before it is removed from the cache
 
 # Main Solr geometry field used for spatial search and bounding box. Should be type 'rpt'
 GEOMETRY_FIELD: "solr_geom"

--- a/lib/tasks/earthworks.rake
+++ b/lib/tasks/earthworks.rake
@@ -155,6 +155,14 @@ namespace :earthworks do
     end
   end
 
+  desc 'Clean earthworks stale download files'
+  task clear_download_cache_stale_files: [:environment] do
+    # Commented line below is for testing purposes, it will just list the files that
+    # would be deleted with timestamp created
+    # `find /var/cache/earthworks/downloads -type f -atime +14 -printf '%TY-%Tm-%Td %TH:%TM %p\n'`
+    `find #{Settings.DOWNLOAD_PATH} -type f -atime +#{Settings.download_cache_expiry_time_days} -delete`
+  end
+
   desc 'Prune old search data from the database'
   task :prune_old_search_data, [:days_old] => [:environment] do |_t, args|
     chunk = 20_000


### PR DESCRIPTION
Fixes #205 -- add a scheduled rake task for clearing stale download files

Configured to run daily and clear any files not accessed in the last 2 weeks (time period configurable in settings).

Tested find command manually on server (but nothing deleted).

~~See also https://github.com/sul-dlss/shared_configs/pull/2220 which is required first.~~

~~Note, we may want to set the download cache directory in stage shared configs here: https://github.com/sul-dlss/shared_configs/blob/earthworks-stage/config/settings/production.yml#L1  to match what is in in prod: https://github.com/sul-dlss/shared_configs/blob/earthworks-prod/config/settings/production.yml#L1~~

~~it is currently set to `nil` in stage, which will cause problems with this cron job~~