### PR TITLE
Earthworks::Harvester - skip restricted records from other institutions

### DIFF
--- a/lib/earthworks/harvester.rb
+++ b/lib/earthworks/harvester.rb
@@ -25,10 +25,18 @@ module Earthworks
 
     # Some records have placeholder data or are otherwise problematic, but we
     # can't denylist them at the institution/repository level.
-    def skip_record?(_record, path)
+    def skip_record?(record, path)
       # Skip PolicyMap records in shared-repository; they have placeholder data
-      # See https://github.com/OpenGeoMetadata/shared-repository/tree/master/gbl-policymap
-      record_repo(path) == 'shared-repository' && path.include?('gbl-policymap')
+      #   See https://github.com/OpenGeoMetadata/shared-repository/tree/master/gbl-policymap
+      # Skip other institutions' restricted records (need not check instituion here: Stanford records already filtered)
+      #   See https://github.com/sul-dlss/earthworks/issues/1089
+      (record_repo(path) == 'shared-repository' && path.include?('gbl-policymap')) || restricted?(record)
+    end
+
+    def restricted?(record)
+      # no need to check dc_rights_s, that was the field name under schema 1.0, but we don't expect
+      # to switch back from Aardvark
+      record.fetch('dct_accessRights_s', '').downcase == 'restricted'
     end
 
     # We transform some records in order to get more consistent metadata display

--- a/spec/lib/earthworks/harvester_spec.rb
+++ b/spec/lib/earthworks/harvester_spec.rb
@@ -6,7 +6,7 @@ require 'earthworks/harvester'
 require 'spec_helper'
 
 RSpec.describe Earthworks::Harvester do
-  subject(:harvester) { described_class.new(ogm_repos: ogm_repos, ogm_path: ogm_path) }
+  subject(:harvester) { described_class.new(ogm_repos: ogm_repos, ogm_path: ogm_path, schema_version: 'Aardvark') }
 
   let(:ogm_path) { 'tmp/ogm' }
   let(:ogm_repos) do
@@ -60,23 +60,39 @@ RSpec.describe Earthworks::Harvester do
 
   describe '#docs_to_index' do
     # Provenance value will be transformed by our ogm_repos config
-    let(:psu_doc) { { schema_provider_s: 'Pennsylvania State University', geoblacklight_version: '1.0' }.to_json }
-    let(:psu_path) { "#{ogm_path}/edu.psu/metadata-1.0/Maps/08d-01/geoblacklight.json" }
+    let(:psu_doc) { { schema_provider_s: 'Pennsylvania State University', gbl_mdVersion_s: 'Aardvark' }.to_json }
+    let(:psu_path) { "#{ogm_path}/edu.psu/metadata-aardvark/Maps/08d-01/geoblacklight.json" }
 
     # PolicyMap records have placeholder data and should be skipped
-    let(:policymap_doc) { { schema_provider_s: 'Geoblacklight', geoblacklight_version: '1.0' }.to_json }
+    let(:policymap_doc) { { schema_provider_s: 'Geoblacklight', gbl_mdVersion_s: 'Aardvark' }.to_json }
     let(:policymap_path) { "#{ogm_path}/shared-repository/gbl-policymap/records/geoblacklight.json" }
 
+    let(:psu_doc2_hash) { { schema_provider_s: 'Pennsylvania State University', gbl_mdVersion_s: 'Aardvark' } }
+    let(:psu_doc2) { psu_doc2_hash.to_json }
+    let(:psu_path2) { "#{ogm_path}/edu.psu/metadata-aardvark/Maps/08d-01/geoblacklight_2.json" }
+
     before do
-      allow(Find).to receive(:find).and_yield(psu_path).and_yield(policymap_path)
+      allow(Find).to receive(:find).and_yield(psu_path).and_yield(policymap_path).and_yield(psu_path2)
       allow(File).to receive(:read).with(psu_path).and_return(psu_doc)
       allow(File).to receive(:read).with(policymap_path).and_return(policymap_doc)
+      allow(File).to receive(:read).with(psu_path2).and_return(psu_doc2)
     end
 
-    it 'supports skipping arbitrary records' do
+    it 'skips PolicyMap records in shared-repository' do
       docs = harvester.docs_to_index.to_a
-      expect(docs.length).to eq(1)
+      expect(docs.length).to eq(2)
       expect(docs.first.last).to eq(psu_path)
+      expect(docs.last.last).to eq(psu_path2)
+    end
+
+    context 'when access is restricted' do
+      let(:psu_doc2) { psu_doc2_hash.merge({ dct_accessRights_s: 'Restricted' }).to_json }
+
+      it 'skips the record' do
+        docs = harvester.docs_to_index.to_a
+        expect(docs.length).to eq(1)
+        expect(docs.first.last).to eq(psu_path)
+      end
     end
 
     it 'supports transforming arbitrary records' do


### PR DESCRIPTION
as part of that, update Earthworks::Harvester spec to consistently use the Aardvark schema (since the app has already switched over to that schema and we have to use one of its fields in this work)

part of https://github.com/sul-dlss/earthworks/issues/1089