### PR TITLE
update to latest geoblacklight

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/geoblacklight/geoblacklight.git
-  revision: dfbfe52984a4feda6749dd56e7b8c8af69c4cb67
+  revision: d75b12677cf1330737af2e9ecda7e417a244713a
   branch: main
   specs:
     geoblacklight (4.4.0)


### PR DESCRIPTION
fixes https://github.com/sul-dlss/earthworks/issues/1098

displays without error when no search terms are given and no facet is chosen:
<img width="1428" alt="Screenshot 2024-07-23 at 10 32 54 PM" src="https://github.com/user-attachments/assets/21d78e7a-e43e-4c95-ba00-18c4d9ce1110">
