### PR TITLE
Code snippety

### DIFF
--- a/app/assets/javascripts/modules/copy_clipboard.js
+++ b/app/assets/javascripts/modules/copy_clipboard.js
@@ -1,0 +1,71 @@
+/*
+ * This code is used by the copy to clipboard function for the code snippet modal
+*/
+const setupCopyToClipboardListener = function () {
+  const modalElement = document.getElementById("blacklight-modal");
+  
+  // For a click event on the modal itself, capture that and then check if it is the clipboard copy button
+  modalElement.addEventListener("click", function(e){
+    const button = e.target.closest(".btn-clipboard");
+    if (button) {
+      // Copy the text content from the selected pane
+      copyActivePaneContent();
+      // Change the text of the click button and add a checked icon
+      displayCopyClick();
+    }
+    const tabPane = e.target.closest(".code-snippet-tab");
+    if(tabPane) {
+      resetCopyClick();
+    }
+  })
+}
+
+// Copy active code panel's code, based on which programming language the user has selected
+const resetCopyClick = function() {
+  const copyButtonText = document.querySelector("span#copyClipText");
+  const copyCheck = document.querySelector("span#copyCheck");
+  if(! copyButtonText) {
+    console.log("Error finding copy button");
+    return;
+  }
+
+  // Check if the check mark is visible, toggle on that basis
+  if(! copyCheck.classList.contains("d-none")) {
+    copyButtonText.innerHTML = "Copy";
+    copyCheck.classList.add("d-none");
+  }
+}
+
+const displayCopyClick = function() {
+  const copyButtonText = document.querySelector("span#copyClipText");
+  const copyCheck = document.querySelector("span#copyCheck");
+  if(! copyButtonText) {
+    console.log("Error finding copy button");
+    return;
+  }
+
+  // If the check mark is not visible, then show the checkmark and change the text
+  if(copyCheck.classList.contains("d-none")) {
+    copyButtonText.innerHTML = "Copied";
+    copyCheck.classList.remove("d-none");
+  }
+}
+
+//
+const copyActivePaneContent = function() {
+  const codeText = document.querySelector("div#codeContent div.tab-pane.active pre code");
+  if(! codeText) {
+    console.log("Error copying content.  Code was not found");
+    return;
+  }
+
+  try {
+    navigator.clipboard.writeText(codeText.textContent)
+  } catch (e) {
+    console.warn(e);
+  }  
+}
+
+// Load the viewer on page load and Turbolinks page change
+document.addEventListener("DOMContentLoaded", setupCopyToClipboardListener);
+document.addEventListener("turbolinks:load", setupCopyToClipboardListener);

--- a/app/assets/stylesheets/modules/show.scss
+++ b/app/assets/stylesheets/modules/show.scss
@@ -38,3 +38,54 @@ dd[itemprop='url'] a {
   width: 100%;
   min-height: 493px;
 }
+
+// Styles for code snippet
+
+/*
+.code-snippet-tab {
+  color:$primary;
+}
+
+.code-snippet-tab.nav-link.active {
+  color:$primary;
+}
+
+.code-snippet-tab.active {
+  text-decoration: underline !important;
+  text-decoration-color: $primary !important;
+}
+  */
+
+.code-snippet-content {
+  background-color: #f4f4f4 !important;
+  font-size: 1.2em;
+}
+
+.code-snippet-tab {
+  color: $primary;
+  font-size: 1.5rem;
+
+  &.active {
+    color: $primary;
+    text-decoration: underline !important;
+    text-decoration-color: $primary !important;
+  }
+
+  &.nav-link.active {
+    color: $primary;
+  }
+}
+
+.bd-clipboard {
+  position:relative;
+  float:right;
+}
+
+.btn-clipboard{
+  background-color: white !important;
+
+  &:active, &:hover, &:focus {
+    color: #00548F !important;
+    border-color: #00548F !important;
+  }
+}

--- a/app/components/earthworks/code_snippet_modal_component.html.erb
+++ b/app/components/earthworks/code_snippet_modal_component.html.erb
@@ -1,0 +1,49 @@
+<%= render Blacklight::System::ModalComponent.new do |component| %>
+  <% component.with_title { t('geoblacklight.code_snippet.title') } %>
+  <% component.with_body do %>
+    <!-- Bootstrap 5 will require data-bs-toggle and data-bs-target instead -->
+    <div class="p-3">
+      <div class="mb-2">
+        <ul id='codeNav' class='nav nav-tabs border-0' role='tablist'>
+          <li class="nav-item" role="presentation">
+              <button class="nav-link btn-link border-0 pl-0 active code-snippet-tab" id="python-tab" data-toggle="tab" data-target="#python-code" type="button" role="tab" 
+                aria-controls="python-code" aria-selected="true">Python</button>
+          </li>
+          <li class="nav-item" role="presentation">
+            <button class="nav-link btn-link border-0 code-snippet-tab" id="r-tab" data-toggle="tab" data-target="#r-code"  type="button" role="tab" 
+                aria-controls="r-code" aria-selected="false">R</button>
+          </li>
+          <li class="nav-item" role="presentation">
+            <button class="nav-link btn-link border-0 code-snippet-tab" id="leaflet-tab" data-toggle="tab" data-target="#leaflet-code"  type="button" role="tab" 
+                aria-controls="leaflet-code" aria-selected="false">Leaflet</button>
+          </li>
+        </ul>
+      </div>
+
+      <!-- Copy to clipboard button -->
+      <div class="bd-clipboard p-3">
+        <button id="copyClipboard" class="btn btn-outline-primary btn-clipboard" title="" data-original-title="Copy to clipboard">
+         <span id="copyCheck" class="d-none">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check" viewBox="0 0 16 16">
+            <path d="M10.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425z"/>
+          </svg>
+         </span>
+         <span id="copyClipText">Copy</span>
+        </button>
+      </div>
+
+      <!-- Code snippet content -->
+      <div class="tab-content code-snippet-content" id="codeContent">
+          <div class="tab-pane fade show p-3 active" id="python-code" role="tabpanel" aria-labelledby="python-tab">
+            <%= code_block(render_python) %> 
+          </div>
+          <div class="tab-pane fade p-3" id="r-code" role="tabpanel" aria-labelledby="r-tab">
+            <%= code_block(render_r) %> 
+          </div>
+          <div class="tab-pane fade p-3" id="leaflet-code" role="tabpanel" aria-labelledby="leaflet-tab">
+            <%= code_block(render_leaflet) %> 
+          </div>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/components/earthworks/code_snippet_modal_component.rb
+++ b/app/components/earthworks/code_snippet_modal_component.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+module Earthworks
+  class CodeSnippetModalComponent < ViewComponent::Base
+    def initialize(document)
+      @document = document
+      @raster_data_type = raster_data?
+      @vector_data_type = vector_data?
+      super
+    end
+
+    def code_block(content)
+      sanitize "<pre><code>#{h content}</code></pre>"
+    end
+
+    def render_python
+      substitute_values(retrieve_text('Python'))
+    end
+
+    def render_r
+      substitute_values(retrieve_text('R'))
+    end
+
+    def render_leaflet
+      substitute_values(retrieve_text('Leaflet'))
+    end
+
+    # Incorporate
+    def substitute_values(content)
+      sub_content = content
+
+      # replace DRUID_ID
+      sub_content = sub_content.gsub('<<WXS_ID>>', @document.wxs_identifier) unless @document.wxs_identifier.empty?
+
+      # replace WMS reference
+      unless @document.references.wms.nil? || @document.references.wms.endpoint.nil?
+        sub_content = sub_content.gsub('<<GEOSERVER_WMS>>', @document.references.wms.endpoint)
+      end
+
+      # replace WFS reference
+      unless @document.references.wfs.nil? || @document.references.wfs.endpoint.nil?
+        sub_content = sub_content.gsub('<<GEOSERVER_WFS>>', @document.references.wfs.endpoint)
+      end
+
+      # Replace Bounding box information
+      unless @document.geom_field.empty?
+        geometry = @document.geometry.geom
+        bbox_array = geometry.split('ENVELOPE(')[1].split(')')[0].split(',').map(&:strip)
+
+        if bbox_array.length == 4
+          min_x = bbox_array[0]
+          max_x = bbox_array[1]
+          min_y = bbox_array[2]
+          max_y = bbox_array[3]
+
+          sub_content = sub_content.gsub('<<MIN_X>>', min_x)
+          sub_content = sub_content.gsub('<<MIN_Y>>', min_y)
+          sub_content = sub_content.gsub('<<MAX_X>>', max_x)
+          sub_content = sub_content.gsub('<<MAX_Y>>', max_y)
+        end
+      end
+      sub_content
+    end
+
+    private
+
+    # Get the code sample text based on the data type and programming language
+    def retrieve_text(language)
+      file_name = code_sample_file_name(language)
+      return if file_name.empty?
+
+      File.read(Rails.root.join('config', 'code_samples', file_name).to_s).to_s
+    end
+
+    def vector_data?
+      return false unless @document.key?(Settings.FIELDS.RESOURCE_TYPE)
+
+      vector_types = ['polygon data', 'point data', 'line data', 'index maps',
+                      'vector data']
+
+      # If the intersection of these arrays is not empty, then there is at least one vector type value
+      !(@document[Settings.FIELDS.RESOURCE_TYPE].map(&:downcase) &
+        vector_types).empty?
+    end
+
+    def raster_data?
+      return false unless @document.key?(Settings.FIELDS.RESOURCE_TYPE)
+
+      @document[Settings.FIELDS.RESOURCE_TYPE].map(&:downcase).include?('raster data')
+    end
+
+    def code_sample_file_name(language)
+      case language
+      when 'Python'
+        @vector_data_type ? 'vector_python.txt' : 'raster_python.txt'
+      when 'Leaflet'
+        @vector_data_type ? 'vector_leaflet.txt' : 'raster_leaflet.txt'
+      when 'R'
+        @vector_data_type ? 'vector_r.txt' : 'raster_r.txt'
+      end
+    end
+  end
+end

--- a/app/components/earthworks/code_snippet_modal_component.rb
+++ b/app/components/earthworks/code_snippet_modal_component.rb
@@ -32,6 +32,9 @@ module Earthworks
       # replace DRUID_ID
       sub_content = sub_content.gsub('<<WXS_ID>>', @document.wxs_identifier) unless @document.wxs_identifier.empty?
 
+      # If layer id is required
+      sub_content = sub_content.gsub('<<LAYER_ID>>', layer_id) unless layer_id.nil?
+
       # replace WMS reference
       unless @document.references.wms.nil? || @document.references.wms.endpoint.nil?
         sub_content = sub_content.gsub('<<GEOSERVER_WMS>>', @document.references.wms.endpoint)
@@ -60,6 +63,15 @@ module Earthworks
         end
       end
       sub_content
+    end
+
+    def layer_id
+      # If the Solr document either does not have a wxs identifier or does not have the "druid:" prefix
+      unless @document.wxs_identifier.empty? || @document.wxs_identifier.exclude?('druid:')
+        return @document.wxs_identifier.split('druid:')[1]
+      end
+
+      nil
     end
 
     private

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -314,6 +314,9 @@ class CatalogController < ApplicationController
                                                           options[:document] &&
                                                             options[:document].searchworks_url.present?
                                                         }
+    # This may go elsewhere
+    # config.add_show_tools_partial(:code_snippet_component)
+    config.add_show_tools_partial(:code_snippet_link, partial: 'code_snippet_link')
 
     config.show.document_actions.delete(:sms)
 
@@ -341,5 +344,17 @@ class CatalogController < ApplicationController
   # @return [Boolean]
   def has_search_parameters?
     !params[:q].nil? || super
+  end
+
+  ## Adding code snippet function, uses code_snippet partial
+  def code_snippet
+    @response, @documents = action_documents
+
+    respond_to do |format|
+      format.html do
+        return render layout: false if request.xhr?
+        # Otherwise draw the full page
+      end
+    end
   end
 end

--- a/app/views/catalog/_code_snippet_link.html.erb
+++ b/app/views/catalog/_code_snippet_link.html.erb
@@ -1,0 +1,4 @@
+<%= link_to "Code Snippet",
+                url_for(controller: controller_name, action: "code_snippet"),
+                id: @id,
+                data: { blacklight_modal: "trigger" } %>

--- a/app/views/catalog/code_snippet.html.erb
+++ b/app/views/catalog/code_snippet.html.erb
@@ -1,0 +1,1 @@
+<%= render Earthworks::CodeSnippetModalComponent.new(@documents.first) %>

--- a/config/code_samples/raster_leaflet.txt
+++ b/config/code_samples/raster_leaflet.txt
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Leaflet WMS Map</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <style>
+        #map {
+            height: 100vh;
+        }
+    </style>
+</head>
+<body>
+    <div id="map"></div>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script>
+        // Configuration variables
+        const wmsEndpoint = "<<GEOSERVER_WMS>>";
+        const layerId = `<<WXS_ID>>`;
+
+        // Initialize the map
+        const map = L.map('map');
+
+        // Add a base layer for better context
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        }).addTo(map);
+
+        // Add the WMS layer
+        const wmsLayer = L.tileLayer.wms(wmsEndpoint, {
+            layers: layerId,
+            format: 'image/png',
+            transparent: true,
+            version: '1.1.0',
+            attribution: '© Stanford'
+        }).addTo(map);
+
+        // Set the map view based on the layer's bounding box
+        const bounds = [[<<MIN_Y>>, <<MIN_X>>], [<<MAX_Y>>, <<MAX_X>>]];
+        map.fitBounds(bounds);
+    </script>
+</body>
+</html>

--- a/config/code_samples/raster_python.txt
+++ b/config/code_samples/raster_python.txt
@@ -1,0 +1,10 @@
+Raster Python content: Coming soon
+
+Information that may be used in this code: 
+
+- Geoserver WMS URL: <<GEOSERVER_WMS>>
+- Bounding box: 
+-- Max x :  <<MAX_X>>
+-- Max y : <<MAX_Y>>
+-- Min y : <<MIN_Y>>
+-- Min x : <<MIN_X>>

--- a/config/code_samples/raster_python.txt
+++ b/config/code_samples/raster_python.txt
@@ -1,10 +1,62 @@
-Raster Python content: Coming soon
+# Before running this code, install or check for these libraries
+# pip install rasterio matplotlib
+import requests
+import zipfile
+import io
+import rasterio
+from rasterio.plot import show
+import matplotlib.pyplot as plt
+import os
 
-Information that may be used in this code: 
+def download_and_display_geotiff(layer_name):
+    # Construct URL to the zip file
+    zip_url = f"https://stacks.stanford.edu/object/{layer_name}"
+    
+    # Fetch the zip file
+    response = requests.get(zip_url)
+    
+    # Path to extract the zip file
+    extract_path = f"./{layer_name}"
+    os.makedirs(extract_path, exist_ok=True)
+    
+    # Unzip the outer zip file
+    with open(f"{extract_path}/{layer_name}.zip", "wb") as f:
+        f.write(response.content)
+        
+    with zipfile.ZipFile(f"{extract_path}/{layer_name}.zip", 'r') as zip_ref:
+        zip_ref.extractall(extract_path)
+    
+    # Find the inner zip file (data.zip)
+    inner_zip_path = os.path.join(extract_path, "data.zip")
+    
+    if not os.path.exists(inner_zip_path):
+        print("No inner zip file (data.zip) found.")
+        return
 
-- Geoserver WMS URL: <<GEOSERVER_WMS>>
-- Bounding box: 
--- Max x :  <<MAX_X>>
--- Max y : <<MAX_Y>>
--- Min y : <<MIN_Y>>
--- Min x : <<MIN_X>>
+    # Unzip the inner zip file
+    with zipfile.ZipFile(inner_zip_path, 'r') as inner_zip_ref:
+        inner_zip_ref.extractall(extract_path)
+
+    # Find the GeoTIFF file in the extracted contents
+    geotiff_filename = None
+    for root, dirs, files in os.walk(extract_path):
+        for file in files:
+            if file.endswith('.tif'):
+                geotiff_filename = os.path.join(root, file)
+                break
+
+    if geotiff_filename is None:
+        print("No GeoTIFF file found in the extracted contents.")
+        return
+
+    # Load the GeoTIFF file into rasterio
+    with rasterio.open(geotiff_filename) as dataset:
+        # Plot the image data using matplotlib
+        plt.figure(figsize=(10, 10))
+        plt.title(f"Raster Data for {layer_name}")
+        show(dataset, cmap='gray')
+        plt.close()
+
+# Example usage
+layer_name = "<<LAYER_ID>>"
+download_and_display_geotiff(layer_name)

--- a/config/code_samples/raster_r.txt
+++ b/config/code_samples/raster_r.txt
@@ -1,10 +1,41 @@
-Raster Python content: Coming soon
+# Load necessary libraries
+library(httr)
+library(zip)
+library(raster)
+library(tiff)
 
-Information that may be used in this code: 
+# Define the layer name
+layer_name <- "<<LAYER_ID>>"
 
-- Geoserver WMS URL: <<GEOSERVER_WMS>>
-- Bounding box: 
--- Max x :  <<MAX_X>>
--- Max y : <<MAX_Y>>
--- Min y : <<MIN_Y>>
--- Min x : <<MIN_X>>
+# Construct URL to the zip file
+zip_url <- paste0("https://stacks.stanford.edu/object/", layer_name)
+
+# Define the file paths
+zip_file_path <- paste0(layer_name, ".zip")
+extract_path <- paste0("./", layer_name)
+dir.create(extract_path, showWarnings = FALSE)
+
+# Download the zip file
+GET(zip_url, write_disk(zip_file_path, overwrite = TRUE))
+
+# Unzip the outer zip file
+unzip(zip_file_path, exdir = extract_path)
+
+# Find the inner zip file (data.zip)
+inner_zip_path <- file.path(extract_path, "data.zip")
+
+# Unzip the inner zip file
+unzip(inner_zip_path, exdir = extract_path)
+
+# Find the GeoTIFF file in the extracted contents
+tif_files <- list.files(extract_path, pattern = "\\.tif$", full.names = TRUE)
+
+if (length(tif_files) == 0) {
+    stop("No GeoTIFF file found in the extracted contents.")
+}
+
+# Load the GeoTIFF file
+r <- raster(tif_files[1])
+
+# Plot the image data
+plot(r, col = gray.colors(256), main = paste("Raster Data for", layer_name))

--- a/config/code_samples/raster_r.txt
+++ b/config/code_samples/raster_r.txt
@@ -1,0 +1,10 @@
+Raster Python content: Coming soon
+
+Information that may be used in this code: 
+
+- Geoserver WMS URL: <<GEOSERVER_WMS>>
+- Bounding box: 
+-- Max x :  <<MAX_X>>
+-- Max y : <<MAX_Y>>
+-- Min y : <<MIN_Y>>
+-- Min x : <<MIN_X>>

--- a/config/code_samples/vector_leaflet.txt
+++ b/config/code_samples/vector_leaflet.txt
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Leaflet WFS Layer</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet-ajax@2.1.0/dist/leaflet.ajax.js"></script>
+</head>
+
+<body>
+    <div id="map" style="width: 100%; height: 100vh;"></div>
+    <script>
+        var map = L.map('map').setView([0, 0], 2);
+
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 19,
+        }).addTo(map)
+        var geojsonLayer = new L.GeoJSON.AJAX("<<GEOSERVER_WFS>>?service=WFS&" +
+            "version=1.1.0&request=GetFeature&typename=<<WXS_ID>>" +
+            "outputFormat=application/json&srsname=EPSG:4326", {
+            onEachFeature: function (feature, layer) {
+                var popupContent = '';
+                for (var key in feature.properties) {
+                    popupContent += key + ': ' + feature.properties[key] + '<br>';
+                }
+                layer.bindPopup(popupContent);
+            }
+        }).addTo(map);
+
+        geojsonLayer.on('data:loaded', function () {
+            map.fitBounds(geojsonLayer.getBounds());
+        });
+    </script>
+</body>
+
+</html>

--- a/config/code_samples/vector_python.txt
+++ b/config/code_samples/vector_python.txt
@@ -1,0 +1,38 @@
+
+# Before running this code, install or check for these libraries
+# !pip install geopandas folium
+
+# Accept user input for the GeoServer URL and the typeName of the layer
+geoserver_url = "<<GEOSERVER_WFS>>?"
+type_name = "<<WXS_ID>>"
+
+# Define the parameters for the WFS service
+params = {
+    'service': 'WFS',
+    'version': '2.0.0',
+    'request': 'GetFeature',
+    'typeName': type_name,
+    'outputFormat': 'application/json'
+}
+
+# Send a GET request to the GeoServer WFS service
+response = requests.get(geoserver_url, params=params)
+
+# Get the bounds of the GeoDataFrame
+bounds = gdf.total_bounds
+
+# Calculate the center of the bounds
+center = [(bounds[1] + bounds[3]) / 2, (bounds[0] + bounds[2]) / 2]
+
+# Create the map
+m = folium.Map(location=center, zoom_start=2)
+
+# Load the features from the WFS service into a GeoDataFrame
+gdf = gpd.read_file(response.text)
+
+
+# Add the GeoDataFrame to the map as a GeoJson layer
+folium.GeoJson(gdf).add_to(m)
+
+# Display the map
+m

--- a/config/code_samples/vector_r.txt
+++ b/config/code_samples/vector_r.txt
@@ -1,0 +1,19 @@
+# Load the necessary libraries
+library(sf)
+library(ggplot2)
+
+# Define the WFS service URL and typename
+geoserver_url <- "<<GEOSERVER_WFS>>?"
+type_name <- "<<WXS_ID>>"
+# Define the WFS request URL
+wfs_url <- paste0(
+    geoserver_url,
+    "service=WFS&version=1.0.0&request=GetFeature&typeName=",
+    type_name, "&outputFormat=application/json"
+)
+# Download the WFS layer
+wfs_layer <- st_read(wfs_url)
+# Plot the WFS layer
+ggplot() +
+    geom_sf(data = wfs_layer) +
+    theme_minimal()

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -7,3 +7,6 @@ en:
       member_of_descendants: 'Collection items'
     formats:
       jpeg2000: 'JP2'
+    code_snippet:
+      title: 'Code snippets'
+      copy: 'Copy'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
     concerns :range_searchable
   end
 
+  get '/catalog/:id/code_snippet' => 'catalog#code_snippet'
   get 'restricted_proxy/geoserver/:webservice' => 'restricted_proxy#access'
 
   devise_for :users, skip: %i[registrations passwords sessions]

--- a/spec/components/earthworks/code_snippet_modal_component_spec.rb
+++ b/spec/components/earthworks/code_snippet_modal_component_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'spec_helper'
+
+RSpec.describe Earthworks::CodeSnippetModalComponent, type: :component do
+  subject(:rendered) do
+    render_inline(described_class.new(document))
+  end
+
+  let(:document_attributes) do
+    {
+      id: 'abc123', gbl_wxsIdentifier_s: 'druid:abc123',
+      locn_geometry: 'ENVELOPE(172.666667, 176.05, 3.416667, -1.975)',
+      dcat_bbox: 'ENVELOPE(172.666667, 176.05, 3.416667, -1.975)',
+      dct_references_s: '{"http://www.opengis.net/def/serviceType/ogc/wms":"wms"}',
+      gbl_resourceType_sm: resource_type
+    }
+  end
+
+  describe 'Initial view for modal' do
+    let(:resource_type) { ['Raster data'] }
+    let(:document) { SolrDocument.new(document_attributes) }
+
+    it 'displays Python language link' do
+      expect(rendered).to have_css('.code-snippet-tab#python-tab')
+    end
+
+    it 'displays R language link' do
+      expect(rendered).to have_css('.code-snippet-tab#r-tab')
+    end
+
+    it 'displays Leaflet language link' do
+      expect(rendered).to have_css('.code-snippet-tab#leaflet-tab')
+    end
+
+    it 'displays Copy button' do
+      expect(rendered).to have_button('copyClipboard')
+    end
+
+    it 'correctly subsitutes WXS identifier' do
+      expect(rendered).to have_content('druid:abc123')
+    end
+  end
+
+  describe 'Raster data view' do
+    let(:resource_type) { ['Raster data'] }
+    let(:document) { SolrDocument.new(document_attributes) }
+
+    it 'correctly substitutes WMS endpoint' do
+      expect(rendered).to have_content('wms')
+    end
+  end
+
+  describe 'Vector data view' do
+    let(:resource_type) { ['Vector data'] }
+    let(:document) { SolrDocument.new(document_attributes) }
+
+    it 'correctly substitutes WFS endpoint' do
+      expect(rendered).to have_content('wfs')
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,9 @@ require 'rspec/rails'
 
 require 'devise'
 require 'factory_bot'
+require 'view_component/test_helpers'
+require 'view_component/system_test_helpers'
+require 'capybara/rspec'
 
 Capybara.javascript_driver = :selenium_chrome_headless
 
@@ -70,4 +73,8 @@ RSpec.configure do |config|
   # The different available types are documented in the features, such as in
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
+  config.include Capybara::DSL
+  config.include ViewComponent::TestHelpers, type: :component
+  config.include ViewComponent::SystemTestHelpers, type: :component
+  config.include Capybara::RSpecMatchers, type: :component
 end


### PR DESCRIPTION
Closes #1049 .

What this pull request does:

Adds the ability to see code samples
- Adds code snippet link to show tools. (Note: the UI designs show this in a different place, so we will need to move the link to the right place once we start working on UI changes)
- Reads code snippets from static files. (Not all the files are complete, and some are placeholders).  
- Uses the following logic to determine which file needs to be displayed:  if resource type is "Raster data", show raster code samples.  If resource type is "Vector data","Polygon data", "Point data", "Line data", or "Index Maps", show vector samples.
- Show tabs for three languages: Python, R, Leaflet. 
- I've added some specific tokens for wxs identifier, geoserver wms, and geoserver wfs within some code samples, to allow these values to be replaced. This will allow the static template to say <<WXS_ID>>, for example, while the code sample page will be able to get that field from the Solr document and insert the value into the page. 
- Clicking the "Copy" button will show "Copied" with a check mark to the left.  Clicking on any of the tab links, including the current one, will change the button text back to "Copy" and hide the check mark. 