### PR TITLE
Align solr versions

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -3,4 +3,4 @@
 collection:
   dir: config/solr_configs/
   name: blacklight-core
-version: 9.6.1
+version: 8.11.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - db:/var/lib/postgresql/data
 
   index:
-    image: solr:8.11.1
+    image: solr:8.11.2
     ports:
       - "8983:8983"
     volumes:


### PR DESCRIPTION
This aligns the solr_wrapper and docker solr versions to match what we are using in production: v8.11.2
