### PR TITLE
Stop pointing at Geoblacklight's main branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ end
 
 gem 'blacklight', '~> 7.33'
 gem 'rsolr' # required for Blacklight
-gem 'geoblacklight', github: 'geoblacklight/geoblacklight', branch: 'main'
+gem 'geoblacklight','~> 4.4'
 gem 'faraday', '~> 2.0'
 gem "devise"
 gem "devise-guests", ">= 0.3.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,3 @@
-GIT
-  remote: https://github.com/geoblacklight/geoblacklight.git
-  revision: 4af93ba5736bf53bbea143545f25d0955536b7ee
-  branch: main
-  specs:
-    geoblacklight (4.4.0)
-      blacklight (~> 7.0)
-      coderay
-      config
-      deprecation
-      faraday (~> 2.0)
-      geo_combine (~> 0.9)
-      handlebars_assets
-      mime-types
-      rails (>= 6.1, < 7.2)
-      rgeo-geojson
-      sprockets-rails (~> 3.0)
-      vite_rails (~> 3.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -245,6 +226,19 @@ GEM
       rsolr
       sanitize
       thor
+    geoblacklight (4.4.0)
+      blacklight (~> 7.0)
+      coderay
+      config
+      deprecation
+      faraday (~> 2.0)
+      geo_combine (~> 0.9)
+      handlebars_assets
+      mime-types
+      rails (>= 6.1, < 7.2)
+      rgeo-geojson
+      sprockets-rails (~> 3.0)
+      vite_rails (~> 3.0)
     git (2.1.1)
       activesupport (>= 5.0)
       addressable (~> 2.8)
@@ -620,7 +614,7 @@ DEPENDENCIES
   factory_bot_rails (~> 6.2.0)
   faraday (~> 2.0)
   geo_combine (>= 0.9)
-  geoblacklight!
+  geoblacklight (~> 4.4)
   honeybadger
   http
   jbuilder (~> 2.5)

--- a/app/helpers/earthworks_geoblacklight_helper.rb
+++ b/app/helpers/earthworks_geoblacklight_helper.rb
@@ -2,7 +2,7 @@ module EarthworksGeoblacklightHelper
   include GeoblacklightHelper
 
   def document_available?(document = @document)
-    super && document.available?
+    document.same_institution? && user_signed_in? && document.available?
   end
 
   # Override to render multi-valued description as individual paragraphs


### PR DESCRIPTION
Now that Geoblacklight has BL8 updates on main, we need to stop
pointing at it unless we want to deploy those changes and break
our own app.
