### PR TITLE
fix legacy icons, info_format

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -225,7 +225,7 @@ WMS_PARAMS:
   :STYLES: ""
   :SRS: "EPSG:4326"
   :EXCEPTIONS: "application/json"
-  :INFO_FORMAT: "text/html"
+  :INFO_FORMAT: "application/json"
 
 # Settings for leaflet
 LEAFLET:
@@ -482,3 +482,17 @@ OGM_REPOS:
     provider: Virginia Tech
 
 IIIF_DRAG_DROP_LINK: '@manifest?manifest=@manifest'
+
+ICON_MAPPING:
+  chicago: university-of-chicago
+  illinois: university-of-illinois-urbana-champaign
+  iowa: university-of-iowa
+  maryland: university-of-maryland
+  michigan-state: michigan-state-university
+  michigan: university-of-michigan
+  minnesota: university-of-minnesota
+  nebraska: university-of-nebraska-lincoln
+  ohio-state: the-ohio-state-university
+  penn-state: pennsylvania-state-university
+  purdue: purdue-university
+  wisconsin: university-of-wisconsin-madison


### PR DESCRIPTION
See https://github.com/geoblacklight/geoblacklight/issues/1446. Since we don't have the fix implemented the icons aren't showing up. Adding the ICON_MAPPING fixes the icons. 
![Screenshot 2024-08-12 at 1 38 54 PM](https://github.com/user-attachments/assets/548377d2-3cef-4439-b4f6-6f81be49a518)

For the line `:INFO_FORMAT: "application/json"` see https://github.com/geoblacklight/geoblacklight/issues/612 and https://github.com/geoblacklight/geoblacklight/pull/1429. Switching to application/json allows highlighting on map when clicked.
