### PR TITLE
move search header into document split

### DIFF
--- a/app/assets/stylesheets/earthworks.css
+++ b/app/assets/stylesheets/earthworks.css
@@ -68,3 +68,18 @@
 .documents-list article:hover, .documents-list article:focus {
   box-shadow: -4px 4px 4px 0px var(--stanford-fog-light);
 }
+
+.search-widgets .btn {
+  --bs-btn-font-size: .875rem;
+  --bs-border-radius: 4px;
+  --bs-btn-padding-x: 6px;
+  --bs-btn-padding-y: 2px;
+  --bs-btn-line-height: 1;
+  height: 1.6rem;
+  align-self: center;
+}
+
+.sort-pagination, .pagination-search-widgets {
+  padding-bottom: .5rem;
+  border-bottom: 2px solid var(--bs-border-color);
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -13,10 +13,11 @@ class CatalogController < ApplicationController
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     config.default_solr_params = {
       :start => 0,
-      :rows => 10,
+      :rows => 20,
       'q.alt' => '*:*'
     }
 
+    config.default_per_page = 20
     # Default parameters to send on single-document requests to Solr.
     # These settings are the Blacklight defaults (see SolrHelper#solr_doc_params) or
     # parameters included in the Blacklight-jetty document requestHandler.

--- a/app/views/catalog/_document_split.html.erb
+++ b/app/views/catalog/_document_split.html.erb
@@ -1,0 +1,22 @@
+<div class='row'>
+  <div
+    id="documents"
+    class="documents-list col-md-6"
+    data-controller="search-results"
+    data-action="leaflet-viewer:loaded@window->search-results#fitResultBounds"
+    data-search-results-leaflet-viewer-outlet=".leaflet-viewer"
+    >
+    <%= render blacklight_config.view_config(document_index_view_type).search_header_component.new %>
+    <turbo-frame id="documents-frame">
+      <% document_presenters = documents.map { |doc| document_presenter(doc) } -%>
+      <% document_presenters.each_with_index do |presenter, index| %>
+        <%= render blacklight_config.index.document_component.new(document: presenter, document_counter: index) %>
+      <% end %>
+    </turbo-frame>
+  </div>
+  <% if results_js_map_selector(controller.controller_name) == "index" %>
+    <%= render(Geoblacklight::LocationLeafletMapComponent.new(page: 'index', geosearch: { dynamic: true }, classes: 'col-md-6 sticky-top position-sticky leaflet-viewer')) %>
+  <% else %>
+    <%= render(Geoblacklight::LocationLeafletMapComponent.new(page: 'index', classes: 'col-md-6 leaflet-viewer')) %>
+  <% end %>
+</div>

--- a/app/views/catalog/_search_header.html.erb
+++ b/app/views/catalog/_search_header.html.erb
@@ -1,0 +1,1 @@
+<%= render 'did_you_mean' %>


### PR DESCRIPTION
update default number of result to 20. Closes #1171

Quick notes
- app/views/catalog/_document_split.html.erb is overriding and override from geoblacklight. The only real change is to add in `   <%= render blacklight_config.view_config(document_index_view_type).search_header_component.new %>` above turbo-frame
- app/views/catalog/_search_header.html.erb is an override from blacklight. In blacklight it renders the search_header_component which has a partial with ```<%= render 'did_you_mean' %>
<%= render 'sort_and_per_page' %>``` so I just moved everything into this file and removed `sort_and_per_page` which is a partial where the only thing in it is `render blacklight_config.view_config(document_index_view_type).search_header_component.new`

![Screenshot 2024-08-14 at 12 55 09 PM](https://github.com/user-attachments/assets/4c145673-6b44-4334-a0a3-89d9c5c28f6b)
