### PR TITLE
Smart suggest using search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -3,6 +3,7 @@ require 'blacklight/catalog'
 class CatalogController < ApplicationController
   include BlacklightRangeLimit::ControllerOverride
   include Blacklight::Catalog
+  include Blacklight::Searchable
 
   configure_blacklight do |config|
     # Ensures that JSON representations of Solr Documents can be retrieved using
@@ -340,5 +341,10 @@ class CatalogController < ApplicationController
         # Otherwise draw the full page
       end
     end
+  end
+
+  def suggest
+    @suggestions = Suggester.suggest(search_service, params[:q])
+    render layout: false
   end
 end

--- a/app/models/suggester.rb
+++ b/app/models/suggester.rb
@@ -1,0 +1,110 @@
+class Suggester
+  def self.suggest(search_service, query)
+    new(search_service, query).suggestions
+  end
+
+  def initialize(search_service, query, max_results: 50)
+    @query = query
+    @search_service = search_service
+    @max_results = max_results
+  end
+
+  def suggestions
+    make_suggestions(search)
+  end
+
+  private
+
+  def search
+    solr_q = "dct_title_ti:#{@query}* OR dct_spatial_tmi:#{@query}*"
+    @search_service.repository.search(
+      q: solr_q,
+      rows: @max_results,
+      fl: %w[id dct_title_s dct_spatial_sm gbl_resourceClass_sm]
+    )
+  end
+
+  def make_suggestions(response)
+    suggestions = Suggestions.new(query: @query)
+
+    response['response']['docs'].each do |solr_doc|
+      suggestions.add(solr_doc)
+    end
+
+    suggestions
+  end
+end
+
+class Suggestions
+  def initialize(query:)
+    @query = query
+    @items = Set.new
+  end
+
+  def add(solr_doc)
+    @items.add(Suggestion.from_solr_doc(solr_doc: solr_doc, query: @query))
+    locations = solr_doc['dct_spatial_sm'] || []
+    locations.each do |loc|
+      @items.add(Suggestion.new(name: loc, types: ['Location'], query: @query))
+    end
+  end
+
+  def locations
+    @locations ||= @items.filter(&:location?)
+  end
+
+  def datasets
+    @datasets ||= @items.filter(&:dataset?)
+  end
+
+  def maps
+    @maps ||= @items.filter(&:map?)
+  end
+end
+
+class Suggestion
+  attr_reader :name, :id, :types
+
+  def self.from_solr_doc(solr_doc:, query:)
+    name = solr_doc['dct_title_s']
+    types = solr_doc['gbl_resourceClass_sm']
+    id = solr_doc['id']
+
+    Suggestion.new(name: name, types: types, query: query, id: id)
+  end
+
+  def initialize(name:, types:, query:, id: nil)
+    @name = name
+    @types = types
+    @query = query
+    @id = id
+  end
+
+  def dataset?
+    @types.include?('Datasets') && match?(@name)
+  end
+
+  def map?
+    @types.include?('Maps') && match?(@name)
+  end
+
+  def location?
+    @types.include?('Location') && match?(@name)
+  end
+
+  def match?(str)
+    str.match?(/\b#{@query}/i)
+  end
+
+  def highlighted_name
+    @name.gsub(/\b(#{@query})/i, '<b>\1</b>')
+  end
+
+  def eql?(other)
+    @name == other.name && @types == other.types
+  end
+
+  def hash
+    [@name, @types].hash
+  end
+end

--- a/app/views/catalog/suggest.html.erb
+++ b/app/views/catalog/suggest.html.erb
@@ -1,0 +1,26 @@
+<% if @suggestions.locations.length > 0 %>
+  <li class="fw-bold" aria-disabled="true">Locations</li>
+  <% @suggestions.locations.first(5).each do |result| %>
+    <li role="option" class="dropdown-item" data-autocomplete-value="<%= strip_tags result.name %>">
+      <span><%= link_to sanitize(result.highlighted_name), controller: 'catalog', params: {"f[dct_spatial_sm][]": strip_tags(result.name)} %></span>
+    </li>
+  <% end %>
+<% end %>
+
+<% if @suggestions.datasets.length > 0 %>
+  <li class="fw-bold" aria-disabled="true">Datasets</li>
+  <% @suggestions.datasets.first(5).each do |result| %>
+  <li role="option" class="dropdown-item">
+    <span><%= link_to sanitize(result.highlighted_name), solr_document_path(result.id) %></span>
+  </li>
+  <% end %>
+<% end %>
+
+<% if @suggestions.maps.length > 0 %>
+  <li class="fw-bold" aria-disabled="true">Maps</li>
+  <% @suggestions.maps.first(5).each do |result| %>
+    <li role="option" class="dropdown-item">
+      <span><%= link_to sanitize(result.highlighted_name), solr_document_path(result.id) %></span>
+    </li>
+  <% end %>
+<% end %>


### PR DESCRIPTION
Implement "smart suggest" using the Solr select endpoint rather than suggest in order to get the document IDs for the title results, so they can be directly linked to.

When the user types in a string a search for the string with `*` appended of `dct_title_ti` and `dct_spatial_tmi` is performed. The results are stored in an instance of the new `Suggestions` class which has methods to return locations, datasets and maps. Each of the suggestions is an instance of `Suggestion` which can highlight the query.

TODO: the Suggester, Suggestions and Suggestion classes need unit tests. I tested with 4k documents and it seemed to perform similarly to the suggest endpoint, but it will be useful to see how it performs with more.

Closes #1047
