### PR TITLE
shows metadata modal link in toolbar if metadata available

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -306,7 +306,9 @@ class CatalogController < ApplicationController
     config.add_show_tools_partial(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
     config.add_show_tools_partial(:citation)
     config.add_show_tools_partial :metadata, if: proc { |_context, _config, options|
-                                                   options[:document] && (Settings.METADATA_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any?
+                                                   options[:document] &&
+                                                     (Settings.METADATA_SHOWN &
+                                                     options[:document].references.refs.map { |x| x.type.to_s }).any?
                                                  }
     config.add_show_tools_partial(:email, callback: :email_action, validator: :validate_email_params)
     config.add_show_tools_partial(:sms, if: :render_sms_action?, callback: :sms_action, validator: :validate_sms_params)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -305,6 +305,9 @@ class CatalogController < ApplicationController
     config.add_results_collection_tool(:per_page_widget)
     config.add_show_tools_partial(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
     config.add_show_tools_partial(:citation)
+    config.add_show_tools_partial :metadata, if: proc { |_context, _config, options|
+                                                   options[:document] && (Settings.METADATA_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any?
+                                                 }
     config.add_show_tools_partial(:email, callback: :email_action, validator: :validate_email_params)
     config.add_show_tools_partial(:sms, if: :render_sms_action?, callback: :sms_action, validator: :validate_sms_params)
 


### PR DESCRIPTION
Fixes #1126 

If you don't add the metadata toolbar link, the action is not available, resulting in an exception if you hit the `/metadata` link manually.  This adds the link if metadata is available to render.

Similar to what is done here: https://github.com/geoblacklight/geoblacklight/blob/032115d9960c3559124d2b4d03a79f9f245a7012/lib/generators/geoblacklight/templates/catalog_controller.rb#L302

![Screenshot 2024-08-15 at 12 31 51 PM](https://github.com/user-attachments/assets/55ab6521-2d82-4fc3-82a9-2be466da3e08)

![Screenshot 2024-08-15 at 12 31 57 PM](https://github.com/user-attachments/assets/ac78de00-e11a-4e43-a6bb-f98d4d9f6437)
