### PR TITLE
update search bar to match figma

### DIFF
--- a/app/assets/stylesheets/earthworks.css
+++ b/app/assets/stylesheets/earthworks.css
@@ -104,3 +104,41 @@
   padding-bottom: .5rem;
   border-bottom: 2px solid var(--bs-border-color);
 }
+
+.search-q {
+  padding-left: 2rem;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='currentColor' class='bi bi-search' viewBox='0 0 16 16'%3E%3Cpath d='M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001q.044.06.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0'/%3E%3C/svg%3E") no-repeat left;
+  background-size: 1.5rem;
+  outline: none;
+}
+
+.input-group > .search-autocomplete-wrapper {
+  border: none;
+}
+
+.search-query-form, .navbar-search .search-query-form{
+  border: 1px solid #ABABA9;
+  padding: .5rem;
+  border-radius: .25rem;
+}
+
+.search-query-form input:focus {
+  box-shadow: none;
+}
+.search-query-form .search-btn {
+  border-radius: .25rem!important;
+}
+
+/* TODO: when we get a new blacklight release (v8.3.1)
+Remove file app/components/blacklight/icons/search_component.rb
+Remove lines 138-140
+Uncomment lines 142-144
+*/
+
+.search-query-form .search-btn .blacklight-icons-search {
+  width: auto;
+}
+
+/* .search-query-form .search-btn .blacklight-icons-search {
+  display: none;
+} */

--- a/app/components/blacklight/icons/search_component.rb
+++ b/app/components/blacklight/icons/search_component.rb
@@ -8,9 +8,7 @@ module Blacklight
     #   Blacklight::Icons::SearchComponent.svg = '<svg>your SVG here</svg>'
     class SearchComponent < Blacklight::Icons::IconComponent
       self.svg = <<~SVG
-        <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="24" height="24" viewBox="0 0 24 24">
-          <path fill="none" d="M0 0h24v24H0V0z"/><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
-        </svg>
+        Search
       SVG
     end
   end


### PR DESCRIPTION
![Screenshot 2024-08-20 at 3 46 20 PM](https://github.com/user-attachments/assets/2573b9f2-f5bf-4533-bc11-a5e38106035b)
![Screenshot 2024-08-20 at 3 46 06 PM](https://github.com/user-attachments/assets/0c486e60-ae0d-4de8-bcc7-19a95ccb2f18)


Right now the text is not displaying so as a stop gap I had the icon display the text. This has been fixed in blacklight but the css isn't available until a new release is published on npm.