### PR TITLE
fix css for search button

### DIFF
--- a/app/assets/stylesheets/earthworks.css
+++ b/app/assets/stylesheets/earthworks.css
@@ -135,7 +135,7 @@ Remove lines 138-140
 Uncomment lines 142-144
 */
 
-.search-query-form .search-btn .blacklight-icons-search {
+.search-query-form .search-btn .blacklight-icons {
   width: auto;
 }
 


### PR DESCRIPTION
When doing this locally I was using bl8.3.1 which fixed the missing name in classes for icons. This will fix how the search button is displaying on uat.