### PR TITLE
DownloadLinksComponent: add download button div class to prevent link text colliding with other page elements

### DIFF
--- a/app/components/earthworks/download_links_component.html.erb
+++ b/app/components/earthworks/download_links_component.html.erb
@@ -5,13 +5,13 @@
 <% if document.direct_download.present? %>
 <% if document.direct_download[:download].is_a? Array %>
     <% document.direct_download[:download].each do |download| %>
-      <div>
+      <div class="text-break">
         <%= download_link_file(download['label'], document.id, download['url']) %>
       </div>
     <% end %>
 <% end %>
 <% if document.direct_download[:download].is_a? String %>
-    <div>
+    <div class="text-break">
       <%= download_link_file(download_text(document.file_format), document.id, document.direct_download[:download]) %>
     </div>
 <% end %>


### PR DESCRIPTION
fixes https://github.com/sul-dlss/earthworks/issues/1201

here's a test on localhost where i hacked in the offending text from the issue description by hardcoding it in the component class' `download_link_file` method:

![Screenshot 2024-08-22 at 7 46 05 AM](https://github.com/user-attachments/assets/659a6d91-bef7-449f-8b6c-c73413e4aafa)

i wasn't sure whether an inline style was acceptable -- went that way because i saw it used elsewhere in the same `.erb`.  but happy to turn into a class if that's better.