### PR TITLE
create logout dropdown

### DIFF
--- a/app/assets/stylesheets/earthworks.css
+++ b/app/assets/stylesheets/earthworks.css
@@ -205,3 +205,9 @@ Uncomment lines 142-144
   color: var(--stanford-digital-blue-dark) !important;
   border-color: var(--stanford-digital-blue-dark) !important;
 }
+
+.logout-dropdown {
+  background-color:  rgb(var(--stanford-palo-alto-dark-rgb));
+  --bs-navbar-active-color: white;
+  border-radius: .25rem;
+}

--- a/app/components/blacklight/top_navbar_component.html.erb
+++ b/app/components/blacklight/top_navbar_component.html.erb
@@ -50,9 +50,14 @@
             >Feedback</a
           >
         </li>
-        <li class="nav-item">
+        <li class="nav-item dropdown">
           <% if helpers.current_user && !helpers.current_user.sunet.blank? %>
-            <%= link_to "#{helpers.current_user.sunet}: Logout", destroy_user_session_path, class: "nav-link" %>
+            <button class="nav-link btn-link logout-dropdown dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+              Logged in: <%= helpers.current_user.display_name ||  helpers.current_user.sunet %>
+            </button>
+            <ul class="dropdown-menu">
+              <li><%= link_to "Logout", destroy_user_session_path, class: "dropdown-item" %></li>
+            </ul>
           <% else %>
             <%= link_to 'Login', new_user_session_path(referrer: request.original_url), class: "nav-link" %>
           <% end %>


### PR DESCRIPTION
closes #1243 

The reason the screenshot shows a sunet because my local doesn't have the display name. By default it will show the display name and fall back to the sunet if the display name doesn't exist.
![Screenshot 2024-08-26 at 11 01 56 AM](https://github.com/user-attachments/assets/72ddf919-7b5d-4cb9-879d-baa28a5ccb31)

![Screenshot 2024-08-28 at 12 52 04 PM](https://github.com/user-attachments/assets/25f56d83-fd51-4670-8e19-6bf45293c51e)

