### PR TITLE
Reduce the app header vertical padding slightly

### DIFF
--- a/app/components/blacklight/top_navbar_component.html.erb
+++ b/app/components/blacklight/top_navbar_component.html.erb
@@ -161,7 +161,7 @@
       <div
         class="col-md-8 d-flex justify-content-center justify-content-md-start"
       >
-        <div class="h1 my-4"><a href="/">Earthworks</a></div>
+        <div class="h1 my-3"><a href="/">Earthworks</a></div>
       </div>
       
     </div>


### PR DESCRIPTION
This matches Figma (or at least gets closer).

Before:
<img width="447" alt="Screenshot 2024-08-26 at 14 24 33" src="https://github.com/user-attachments/assets/6fea56f5-6aef-45e6-a4ec-45fc8ab3d2e5">

After:
<img width="504" alt="Screenshot 2024-08-26 at 14 24 50" src="https://github.com/user-attachments/assets/09503d2e-7176-464b-b91a-3f75653ff625">

Figma:
<img width="510" alt="Screenshot 2024-08-26 at 14 24 17" src="https://github.com/user-attachments/assets/dae98f5f-e9e8-470a-9c58-d7727d1bf9d6">
