### PR TITLE
Bl8 axe spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ group :development, :test do
   gem 'simplecov', require: false
   gem 'solr_wrapper'
   gem 'sqlite3', '~> 1.7'
+  gem "axe-core-rspec"
 end
 
 group :deployment do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,17 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.4.19.0)
       execjs (~> 2)
+    axe-core-api (4.10.0)
+      dumb_delegator
+      virtus
+    axe-core-rspec (4.10.0)
+      axe-core-api (= 4.10.0)
+      dumb_delegator
+      virtus
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     base64 (0.2.0)
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
@@ -161,6 +172,8 @@ GEM
       xpath (~> 3.2)
     chronic (0.10.2)
     coderay (1.1.3)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.3.4)
     config (5.5.1)
       deep_merge (~> 1.2, >= 1.2.1)
@@ -181,6 +194,8 @@ GEM
     deep_merge (1.2.2)
     deprecation (1.1.0)
       activesupport
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     devise (4.9.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -204,6 +219,7 @@ GEM
     dotenv (3.1.2)
     drb (2.2.1)
     dry-cli (1.1.0)
+    dumb_delegator (1.0.0)
     ed25519 (1.3.0)
     erubi (1.13.0)
     execjs (2.9.1)
@@ -264,6 +280,7 @@ GEM
     http-form_data (2.3.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     importmap-rails (2.0.1)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -532,6 +549,7 @@ GEM
     stringio (3.1.1)
     strscan (3.1.0)
     thor (1.3.1)
+    thread_safe (0.3.6)
     timeout (0.4.1)
     turbo-rails (2.0.6)
       actionpack (>= 6.0.0)
@@ -550,6 +568,10 @@ GEM
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
+    virtus (2.0.0)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
     vite_rails (3.0.17)
       railties (>= 5.1, < 8)
       vite_ruby (~> 3.0, >= 3.2.2)
@@ -592,6 +614,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  axe-core-rspec
   bcrypt_pbkdf (~> 1.1)
   blacklight!
   blacklight_dynamic_sitemap (~> 0.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/projectblacklight/blacklight.git
-  revision: 918d8cbb7f97e14c166a6818cb4a9388b4f66668
+  revision: 69373f202753f04ec6aca179fdf8fa01248a9edf
   branch: main
   specs:
     blacklight (8.3.0)
@@ -493,7 +493,7 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     securerandom (0.3.1)
-    selenium-webdriver (4.23.0)
+    selenium-webdriver (4.24.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)

--- a/spec/features/axe_spec.rb
+++ b/spec/features/axe_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'axe-rspec'
+
+RSpec.describe 'Accessibility testing', :js do
+  context 'when logged out' do
+    it 'validates the home page' do
+      visit root_path
+      expect(page).to be_accessible
+    end
+
+    it 'validates an item page' do
+      visit solr_document_path('tufts-cambridgegrid100-04')
+      expect(page).to be_accessible
+    end
+
+    # it 'validates an item page with relationships' do
+    #   visit solr_document_path('p16022coll205:265')
+    #   expect(page).to be_accessible
+    # end
+
+    # it 'validates an bookmarks page' do
+    #   visit solr_document_path('tufts-cambridgegrid100-04')
+    #   find('.checkbox.toggle-bookmark').click
+    #   visit bookmarks_path
+    #   expect(page).to be_accessible
+    # end
+
+    it 'validates the history page' do
+      visit '/search_history'
+      expect(page).to be_accessible
+      visit search_catalog_path({ q: 'index' })
+      visit '/search_history'
+      expect(page).to be_accessible
+    end
+  end
+
+  context 'when logged in' do
+    let(:user) { create(:user) }
+    let(:user_id) { "#{user.sunet_id}@stanford.edu" }
+
+    before do
+      login_as(user, scope: :user)
+    end
+
+    it 'validates the home page' do
+      visit root_path
+      expect(page).to be_accessible
+    end
+
+    it 'validates an item page' do
+      visit solr_document_path('stanford-dp018hs9766')
+      expect(page).to be_accessible
+    end
+
+    # it 'validates an bookmarks page' do
+    #   visit solr_document_path('stanford-dp018hs9766')
+    #   find('.checkbox.toggle-bookmark').click
+    #   visit '/bookmarks'
+    #   expect(page).to be_accessible
+    # end
+  end
+
+  def be_accessible
+    be_axe_clean.excluding('#clover-viewer')
+  end
+end


### PR DESCRIPTION
- Bookmark tests are commented out until bookmarks are added back in
- Line 18-21 keeps failing on 3.2 CI. It works fine locally with both ruby versions. I am commenting out until we remove 3.2 from the testing CI.