### PR TITLE
Change facet background/text color

### DIFF
--- a/app/assets/stylesheets/earthworks.css
+++ b/app/assets/stylesheets/earthworks.css
@@ -1,6 +1,7 @@
 :root {
   --stanford-60-black: #767674;
   --stanford-fog-light-rgb: 244, 244, 244;
+  --stanford-palo-alto-rgb: 23, 94, 84;
 }
 
 /* Selects both #main-content and navbar containers */
@@ -27,7 +28,7 @@
 }
 
 .palo-alto-base {
-  --bs-dark-rgb: 23, 94, 84;
+  --bs-dark-rgb: var(--stanford-palo-alto-rgb);
 }
 
 .home-header .blacklight-icons, .home-header .blacklight-icons svg {
@@ -286,4 +287,10 @@ label.toggle-bookmark {
 
 .facet-values li .selected {
   color: rgba(23, 94, 84) !important;
+}
+
+.facet-limit-active {
+  --bl-facet-active-bg: rgb(var(--stanford-palo-alto-rgb));
+  --bl-facet-active-item-color: rgb(var(--stanford-palo-alto-rgb));
+  border-color: rgb(var(--stanford-palo-alto-rgb));
 }

--- a/app/assets/stylesheets/earthworks.css
+++ b/app/assets/stylesheets/earthworks.css
@@ -277,5 +277,13 @@ label.toggle-bookmark {
 
 /* Have to use !important because we load leaflet.css after earthworks.  */
 .leaflet-container {
-  background-color: #d4dadc!important;
+  background-color: #d4dadc !important;
+}
+
+.facet-limit-active .card-header {
+  background-color: rgba(23, 94, 84) !important;
+}
+
+.facet-values li .selected {
+  color: rgba(23, 94, 84) !important;
 }


### PR DESCRIPTION
Fixes #1262 : change active facet background color, font and border to match the header

**Before:**

![Screenshot 2024-08-27 at 2 22 47 PM](https://github.com/user-attachments/assets/43303faa-bdb4-47ea-8e4a-a7ccf2f1bd63)

**After:**

![Screenshot 2024-08-27 at 2 22 32 PM](https://github.com/user-attachments/assets/7c79ca47-dd03-4a9f-b773-d80a256c7c35)


Testing note: this will only work when a new version of Blacklight is released and Earthworks is updated to use it.

