### PR TITLE
fix parentheses in header

### DIFF
--- a/app/components/blacklight/top_navbar_component.html.erb
+++ b/app/components/blacklight/top_navbar_component.html.erb
@@ -35,7 +35,7 @@
         <li class="nav-item">
           <%= link_to bookmarks_path, id:'bookmarks_nav', class: 'nav-link' do %>
             <%= t('blacklight.header_links.bookmarks') %>
-            <span data-role='bookmark-counter'>(<%= helpers.current_or_guest_user.bookmarks.count %>)</span>
+            (<span data-role='bookmark-counter'><%= helpers.current_or_guest_user.bookmarks.count %></span>)
           <% end %>
         </li>
         <li class="nav-item">


### PR DESCRIPTION
When you bookmark something the parentheses are removed. This PR fixes that. 