### PR TITLE
Center the search widgets below size lg screens

### DIFF
--- a/app/assets/stylesheets/earthworks.css
+++ b/app/assets/stylesheets/earthworks.css
@@ -123,6 +123,13 @@
   }
 }
 
+.page-links {
+  @media (max-width: 991.98px) { 
+    /* override GBL here so that it centers correctly */
+   padding: 0.375rem 0;
+  } 
+}
+
 .sort-pagination, .pagination-search-widgets {
   padding-bottom: .5rem;
   border-bottom: 2px solid var(--bs-border-color);

--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -1,6 +1,6 @@
-<div id="sortAndPerPage" class="sort-pagination d-md-flex justify-content-between" role="navigation" aria-label="<%= t('blacklight.search.per_page.aria_label')%>">
+<div id="sortAndPerPage" class="sort-pagination d-lg-flex justify-content-between" role="navigation" aria-label="<%= t('blacklight.search.per_page.aria_label')%>">
   <%= render partial: "paginate_compact", object: @response if show_pagination? %>
-  <div class="search-widgets">
+  <div class="search-widgets justify-content-center">
     <%= render_results_collection_tools %>
     <div class="expand-collapse btn-group" data-controller="expandcollapse" data-expandcollapse-description-outlet=".description">
       <label class="btn btn-outline-primary active" aria-label="collapse descriptions" data-expandcollapse-target="expandButton">


### PR DESCRIPTION
@dbranchini indicated that this should go to centered below large, not medium. So now we have both: 


<img width="974" alt="Screenshot 2024-08-29 at 18 18 22" src="https://github.com/user-attachments/assets/f0102826-c973-417d-b44c-5bf5911d5afc">
<img width="575" alt="Screenshot 2024-08-29 at 18 20 33" src="https://github.com/user-attachments/assets/3e65657c-044d-472c-b44b-6d93e7b46aae">


