### PR TITLE
replacing KMZ with CSV as download option

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -217,6 +217,13 @@ RELATIONSHIPS_SHOWN:
     label: geoblacklight.relations.version_of_descendants
     query_type: descendants
 
+# Vector data download formats to be displayed
+DOWNLOAD_FORMATS:
+  VECTOR:
+    - 'Shapefile'
+    - 'CSV'
+    - 'GeoJSON'
+
 # WMS Parameters
 WMS_PARAMS:
   :SERVICE: "WMS"


### PR DESCRIPTION
Once the GeoBlacklight PR goes through, we can make this change locally on EarthWorks.

Closes #1300 