### PR TITLE
mobile facet view border and vertical alignment

### DIFF
--- a/app/assets/stylesheets/earthworks.css
+++ b/app/assets/stylesheets/earthworks.css
@@ -320,3 +320,16 @@ label.toggle-bookmark {
   --bs-link-color-rgb: var(--stanford-digital-blue-dark-rgb);
   text-decoration: underline;
 }
+
+/* Override mobile view for facets section in Blacklight */
+.facets {
+  --bl-facets-smallish-border: none;
+  --bl-facets-smallish-padding: 0;
+}
+
+/* To help vertically align on mobile */
+@media (max-width: 991.98px) {
+  .facets-heading {
+    margin-bottom: 0;
+  }
+}


### PR DESCRIPTION
Addresses https://github.com/sul-dlss/earthworks/issues/1277 

To remove the border around the facet section for the mobile view, we override the the border value applied to facets for "smallish-border".  To vertically align the heading and the button, we remove some padding in the facets section and margin values for facet heading that were pushing the text further below.

(Broken out from #1309 - other comments can be reviewed there). 