### PR TITLE
remove turbo-frame for results/bookmark links

### DIFF
--- a/app/views/catalog/_document_split.html.erb
+++ b/app/views/catalog/_document_split.html.erb
@@ -8,12 +8,12 @@
     >
     <% isIndex = results_js_map_selector(controller.controller_name) == "index" %>
     <%= render blacklight_config.view_config(document_index_view_type).search_header_component.new if isIndex%>
-    <turbo-frame id="documents-frame">
+    <div id="documents-container">
       <% document_presenters = documents.map { |doc| document_presenter(doc) } -%>
       <% document_presenters.each_with_index do |presenter, index| %>
         <%= render blacklight_config.index.document_component.new(document: presenter, document_counter: index) %>
       <% end %>
-    </turbo-frame>
+    </div>
   </div>
   <div class="col-lg-5 order-first order-lg-last d-none d-lg-block results-map-container" data-controller="searchmapcontainer">
     <% if results_js_map_selector(controller.controller_name) == "index" %>


### PR DESCRIPTION
closes #1383


There is a way to keep the turbo-frame but it requires adding target="_top" to the link which would require a bunch of overrides in blacklight. I think pushing this down the road is fine.

We could also add a Turbo.visit javascript but again it seems like something better if it is done as part of https://github.com/geoblacklight/geoblacklight/issues/1424