### PR TITLE
Only create the useful bookmark routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
     concerns :exportable
   end
 
-  resources :bookmarks do
+  resources :bookmarks, only: %i[index update create destroy] do
     concerns :exportable
 
     collection do


### PR DESCRIPTION
Bots were hitting the show route, which is not normally used. See https://github.com/projectblacklight/blacklight/pull/3318