### PR TITLE
Add a border to the leaflet viewer to match sul-embed

### DIFF
--- a/app/assets/stylesheets/earthworks.css
+++ b/app/assets/stylesheets/earthworks.css
@@ -195,6 +195,9 @@ Uncomment lines 142-144
 } */
 
 #main-container #leaflet-viewer  {
+  /* match sul-embed border */
+  border: 1px solid black;
+
   @media (min-width: 992px) {
     height: 620px;
   }


### PR DESCRIPTION
Embedded content has a border provided by sul-embed's own
stylesheet. It adds some nice contrast to the page, so I figured
we could make the non-embed viewers match.

![Screenshot 2024-09-11 at 14 58 27](https://github.com/user-attachments/assets/08f7d0cf-cac9-4405-8b53-0805640b6b3f)

