### PR TITLE
Ensure custom facet icons get the correct fill color

### DIFF
--- a/app/assets/stylesheets/earthworks.css
+++ b/app/assets/stylesheets/earthworks.css
@@ -318,6 +318,11 @@ label.toggle-bookmark {
   border-color: rgb(var(--stanford-palo-alto-rgb));
 }
 
+/* Ensure facet icons are all the same color */
+.facet-label .blacklight-icons svg {
+  fill: var(--stanford-60-black);
+}
+
 .header-tools > *:hover, .toggle-bookmark span[data-checkboxsubmit-target="span"]:hover {
   --bs-link-color-rgb: var(--stanford-digital-blue-dark-rgb);
   text-decoration: underline;


### PR DESCRIPTION
The "Other" option in the resource class facet is a local component,
so it was using a blue color instead of the standard gray. This
ensures that custom icon components get the right color.

# Before
![Screenshot 2024-09-12 at 10 41 47](https://github.com/user-attachments/assets/f58dc163-045f-4d0a-81c2-ce0d43b508db)

# After
![Screenshot 2024-09-12 at 10 41 36](https://github.com/user-attachments/assets/00a28fb5-f687-4664-9e4c-a5a039dd48d5)
