### PR TITLE
Only add margin to consecutive paragraphs

### DIFF
--- a/app/assets/stylesheets/earthworks.css
+++ b/app/assets/stylesheets/earthworks.css
@@ -365,3 +365,12 @@ body {
 #main-container {
   flex: 1;
 }
+
+/* Add margin for consecutive paragraphs in item descriptions */
+.document-metadata p {
+  margin-bottom: 0;
+}
+
+.document-metadata p + p {
+  margin-top: 1rem;
+}


### PR DESCRIPTION
This overrides a geoblacklight style to prevent extra margin from being added to item descriptions.

# Before
![Screenshot 2024-09-12 at 15 37 28](https://github.com/user-attachments/assets/19c323b8-cd68-4e1e-8035-0b99374c55a3)

# After
![Screenshot 2024-09-12 at 15 37 40](https://github.com/user-attachments/assets/51ee85ef-b5a9-4d05-bba7-b0e4facc5bd2)