### PR TITLE
Add collapsed class to navbar-toggler button

### DIFF
--- a/app/components/blacklight/top_navbar_component.html.erb
+++ b/app/components/blacklight/top_navbar_component.html.erb
@@ -14,7 +14,7 @@
       >Stanford University Libraries</a
     >
     <button
-      class="navbar-toggler navbar-toggler-right"
+      class="navbar-toggler navbar-toggler-right collapsed"
       type="button"
       data-toggle="collapse"
       data-bs-toggle="collapse"


### PR DESCRIPTION
The 2025-01-07 release of component library adds css that changes the hamburger icon to an X when the menu is open, but it requires that the initial state include `collapsed` class on the button. See https://github.com/sul-dlss/component-library/compare/v2024-12-18...v2025-01-07#diff-02bda451f4ad8d9385f3c922c6ed0ed1cdce7c820bb3e86f8f0ccafa4ebf5889L68-R74

This PR:
<img width="445" alt="Screenshot 2025-01-13 at 5 29 23 PM" src="https://github.com/user-attachments/assets/e946c850-a345-45e9-bca0-a61f6eb72c1f" />

Main:
<img width="451" alt="Screenshot 2025-01-13 at 5 29 11 PM" src="https://github.com/user-attachments/assets/0bd53150-a9a5-49a2-9507-523d0357fc0a" />
