### PR TITLE
Update proxy to work with sul-embed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,3 +87,4 @@ gem "cssbundling-rails", "~> 1.4"
 gem "importmap-rails", "~> 2.0"
 gem "stimulus-rails", "~> 1.3"
 gem "turbo-rails", "~> 2.0"
+gem 'jwt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,8 +112,6 @@ GEM
     base64 (0.2.0)
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
-    bcrypt_pbkdf (1.1.1-arm64-darwin)
-    bcrypt_pbkdf (1.1.1-x86_64-darwin)
     benchmark (0.4.0)
     bigdecimal (3.1.9)
     bindex (0.8.1)
@@ -295,6 +293,8 @@ GEM
     json-schema (5.1.1)
       addressable (~> 2.8)
       bigdecimal (~> 3.1)
+    jwt (2.10.1)
+      base64
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -660,6 +660,7 @@ DEPENDENCIES
   http
   importmap-rails (~> 2.0)
   jbuilder (~> 2.5)
+  jwt
   newrelic_rpm
   okcomputer
   pg

--- a/app/controllers/restricted_proxy_controller.rb
+++ b/app/controllers/restricted_proxy_controller.rb
@@ -26,8 +26,8 @@ class RestrictedProxyController < ApplicationController
       headers[k] = v
     end
 
-    self.status = proxied_response.status
-    send_data proxied_response.body, type: proxied_response.headers['Content-Type'], disposition: 'inline'
+    send_data proxied_response.body, type: proxied_response.headers['Content-Type'], disposition: 'inline',
+                                     status: proxied_response.status
   end
 
   private

--- a/app/controllers/restricted_proxy_controller.rb
+++ b/app/controllers/restricted_proxy_controller.rb
@@ -1,12 +1,33 @@
 class RestrictedProxyController < ApplicationController
-  before_action :authenticate_user!
+  before_action :headers_auth
+
+  def headers_auth
+    JWT.decode(request.params['stacks_token'], Settings.geo_proxy_secret, true, { algorithm: 'HS256' })
+    set_cors_headers
+  rescue JWT::ExpiredSignature
+    render json: { error: 'Expired token' }, status: :unauthorized
+  rescue JWT::DecodeError
+    render json: { error: 'Invalid token' }, status: :unauthorized
+  end
+
+  def set_cors_headers
+    origin = request.origin
+    permitted_origins = [Settings.cors.allow_origin_url]
+    if permitted_origins.include?(origin)
+      response.headers['Access-Control-Allow-Origin'] = origin
+      response.headers['Access-Control-Allow-Credentials'] = true
+    else
+      response.headers['Access-Control-Allow-Origin'] = '*'
+    end
+  end
 
   def access
     proxied_headers.each do |k, v|
       headers[k] = v
     end
+
     self.status = proxied_response.status
-    self.response_body = proxied_response.body
+    send_data proxied_response.body, type: proxied_response.headers['Content-Type'], disposition: 'inline'
   end
 
   private

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -1,0 +1,13 @@
+Config.setup do |config|
+  # Name of the constat exposing loaded settings
+  config.const_name = 'Settings'
+
+  config.use_env = true
+  config.env_prefix = 'SETTINGS'
+  config.env_separator = '__'
+  config.env_converter = :downcase
+  config.env_parse_values = true
+
+  # Ability to remove elements of the array set in earlier loaded settings file. Default: nil
+  # config.knockout_prefix = '--'
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -515,3 +515,8 @@ ICON_MAPPING:
   penn-state: pennsylvania-state-university
   purdue: purdue-university
   wisconsin: university-of-wisconsin-madison
+
+cors:
+  allow_origin_url: 'https://embed-stage.stanford.edu'
+
+geo_proxy_secret: 'my$ecretK3y'

--- a/spec/controllers/restricted_proxy_controller_spec.rb
+++ b/spec/controllers/restricted_proxy_controller_spec.rb
@@ -12,29 +12,30 @@ describe RestrictedProxyController do
 
   context 'with a current user' do
     before do
-      sign_in create(:user)
       allow(HTTP).to receive(:get).and_return(
         double(:response, {
-                 headers: { 'content-disposition' => 'image', 'geowebcache-stuff' => 'foo' },
+                 headers: { 'Content-Type' => 'image/png', 'geowebcache-stuff' => 'foo' },
                  status: 200,
                  body: 'image!'
                })
       )
     end
 
+    let(:stacks_token) { JWT.encode({}, Settings.geo_proxy_secret) }
+
     it 'fetches from the proxy' do
-      get :access, params: { webservice: 'wms', format: 'image/png' }
+      get :access, params: { webservice: 'wms', format: 'image/png', stacks_token: }
       expect(response).to have_http_status(:ok)
     end
 
     it 'returns the body' do
-      get :access, params: { webservice: 'wms', format: 'image/png' }
+      get :access, params: { webservice: 'wms', format: 'image/png', stacks_token: }
       expect(response.body).to eq 'image!'
     end
 
     it 'passes through headers' do
-      get :access, params: { webservice: 'wms', format: 'image/png' }
-      expect(response.headers.to_h).to include 'content-disposition' => 'image',
+      get :access, params: { webservice: 'wms', format: 'image/png', stacks_token: }
+      expect(response.headers.to_h).to include 'content-type' => 'image/png',
                                                'geowebcache-stuff' => 'foo'
     end
   end

--- a/spec/controllers/restricted_proxy_controller_spec.rb
+++ b/spec/controllers/restricted_proxy_controller_spec.rb
@@ -13,11 +13,11 @@ describe RestrictedProxyController do
   context 'with a current user' do
     before do
       allow(HTTP).to receive(:get).and_return(
-        double(:response, {
-                 headers: { 'Content-Type' => 'image/png', 'geowebcache-stuff' => 'foo' },
-                 status: 200,
-                 body: 'image!'
-               })
+        instance_double(HTTP::Response, {
+                          headers: { 'Content-Type' => 'image/png', 'geowebcache-stuff' => 'foo' },
+                          status: 200,
+                          body: 'image!'
+                        })
       )
     end
 


### PR DESCRIPTION
This PR does a couple things:
1. fixes proxy response, the old way was returning a LocalJumpError https://app.honeybadger.io/projects/49895/faults/118259904. This is fixed by https://github.com/sul-dlss/earthworks/pull/1484/files#diff-4d95f4d583481eb175bbf04811a2ac3b579ea7c126965760942081923ed4da09R30 
2. Authorizes the user with a token from stacks instead of having to log in with shibboleth
3. Allows cross origin so sul-embed can request proxy

Part of https://github.com/sul-dlss/sul-embed/issues/2757
