### PR TITLE
Remove rack_attack; challenge bots on the first request

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,6 @@ gem 'redis', '~> 5.0'
 gem 'geo_combine', '>= 0.9' # For OpenGeoMetadata indexing
 gem 'sidekiq', '~> 7.0'
 gem 'whenever', require: false
-gem 'rack-attack' # For throttle configuration
 gem 'recaptcha', '>= 5.4.1'
 gem 'http'
 gem "cssbundling-rails", "~> 1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -664,7 +664,6 @@ DEPENDENCIES
   pg
   propshaft
   puma (~> 6)
-  rack-attack
   rack-cors (~> 2.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 7.1)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -3,6 +3,16 @@ require 'blacklight/catalog'
 class CatalogController < ApplicationController
   include Blacklight::Catalog
 
+  # Protect searches with bot_challenge_page & turnstile
+  # See: https://github.com/samvera-labs/bot_challenge_page
+  #
+  # We protect requests for searches, but not for show pages, so we can still
+  # crawl ourselves and let well-behaved search engines index our content via
+  # the sitemap.
+  before_action only: :index do |controller|
+    BotChallengePage::BotChallengePageController.bot_challenge_enforce_filter(controller, immediate: true)
+  end
+
   configure_blacklight do |config|
     # Ensures that JSON representations of Solr Documents can be retrieved using
     # the path /catalog/:id/raw

--- a/config/initializers/bot_challenge_page.rb
+++ b/config/initializers/bot_challenge_page.rb
@@ -14,29 +14,6 @@ Rails.application.config.to_prepare do
   # Do the challenge "in place" on the page the user was on
   BotChallengePage::BotChallengePageController.bot_challenge_config.redirect_for_challenge = false
 
-  # What paths do you want to protect?
-  #
-  # You can use path prefixes: "/catalog" or even "/"
-  #
-  # Or hashes with controller and/or action:
-  #
-  #   { controller: "catalog" }
-  #   { controller: "catalog", action: "index" }
-  #
-  # Note that we can only protect GET paths, and also think about making sure you DON'T protect
-  # any path your front-end needs JS `fetch` access to, as this would block it
-  #
-  # We protect CatalogController requests for searches, but not for show pages, so we can still
-  # crawl ourselves and let well-behaved search engines index our content via the sitemap.
-  BotChallengePage::BotChallengePageController.bot_challenge_config.rate_limited_locations = [
-    { controller: 'catalog', action: 'index' }
-  ]
-
-  # Allow rate_limit_count requests in rate_limit_period, before issuing challenge
-  # This is low because some bots rotate IPs, so we want to catch them quickly
-  BotChallengePage::BotChallengePageController.bot_challenge_config.rate_limit_period = 24.hours
-  BotChallengePage::BotChallengePageController.bot_challenge_config.rate_limit_count = 3
-
   # How long will a challenge success exempt a session from further challenges?
   # BotChallengePage::BotChallengePageController.bot_challenge_config.session_passed_good_for = 36.hours
 
@@ -50,8 +27,5 @@ Rails.application.config.to_prepare do
 
   # More configuration is available; see:
   # https://github.com/samvera-labs/bot_challenge_page/blob/main/app/models/bot_challenge_page/config.rb
-
-  # This gets called last; we use rack_attack to do the rate limiting part
-  BotChallengePage::BotChallengePageController.rack_attack_init
 end
 # rubocop:enable Layout/LineLength


### PR DESCRIPTION
This will help us catch bots that rotate IPs aggressively and
never use the same one twice.
