### PR TITLE
Update indexing-related configuration

### DIFF
--- a/app/consumers/sdr_consumer.rb
+++ b/app/consumers/sdr_consumer.rb
@@ -1,7 +1,7 @@
 # Harvest items published from SDR for indexing
 class SdrConsumer < Racecar::Consumer
-  subscribes_to Settings.kafka.topic
-  self.group_id = Settings.kafka.group_id
+  subscribes_to Settings.indexer_topic
+  self.group_id = Settings.indexer_group
 
   def initialize(
     target: Settings.purl_fetcher.target.downcase,

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -41,6 +41,10 @@ set :honeybadger_env, fetch(:stage)
 # Role for scheduled one-off tasks that run on a single machine
 set :whenever_roles, [:cron]
 
+# Manage racecar via systemd (from dlss-capistrano gem)
+set :racecar_systemd_role, :indexer
+set :racecar_systemd_use_hooks, true
+
 # update shared_configs before restarting app
 before 'deploy:restart', 'shared_configs:update'
 

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -2,7 +2,7 @@ set :bundle_without, %w[test development deployment].join(' ')
 
 server 'earthworks-prod-a.stanford.edu', user: 'geostaff', roles: %w[web db app]
 server 'earthworks-prod-b.stanford.edu', user: 'geostaff', roles: %w[web db app]
-server 'earthworks-worker-prod-a.stanford.edu', user: 'geostaff', roles: %w[app background cron]
+server 'earthworks-worker-prod-a.stanford.edu', user: 'geostaff', roles: %w[app background cron indexer]
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -2,7 +2,7 @@ set :bundle_without, %w[test development deployment].join(' ')
 
 server 'earthworks-stage-a.stanford.edu', user: 'geostaff', roles: %w[web db app]
 server 'earthworks-stage-b.stanford.edu', user: 'geostaff', roles: %w[web db app]
-server 'earthworks-worker-stage-a.stanford.edu', user: 'geostaff', roles: %w[app background cron]
+server 'earthworks-worker-stage-a.stanford.edu', user: 'geostaff', roles: %w[app background cron indexer]
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -527,13 +527,24 @@ geo_proxy_secret: 'my$ecretK3y'
 
 ## Indexing settings
 
-kafka:
-  topic: testing_topic # purl_fetcher_stage, purl_fetcher_prod
-  group_id: testing_group # earthworks-stage-indexer, earthworks-prod-indexer
+# Should be purl_fetcher_stage or purl_fetcher_prod; determines which queue
+# of SDR item updates we are 'listening' to
+indexer_topic: purl_fetcher_stage 
 
+# Kafka groups split messages across consumers; we don't want to take messages
+# from the 'real' stage/prod indexers so we set this to a different value
+indexer_group: earthworks-dev-indexer
+
+# Target should always be earthworks since we don't want to receive items
+# released to e.g. searchworks
 purl_fetcher:
-  target: earthworks # case-insensitive
+  target: earthworks # case-insensitive ("EarthWorks", "Earthworks", etc.)
   skip_catkey: true # skip indexing if item has a catkey
+
+# Determines the environment that cocina metadata will be fetched from; for
+# stage indexing it should be set to staging PURL
+purl:
+  hostname: purl.stanford.edu
 
 # Enable/disable global alerts
 # https://github.com/sul-dlss/global_alerts

--- a/spec/consumers/sdr_consumer_spec.rb
+++ b/spec/consumers/sdr_consumer_spec.rb
@@ -17,10 +17,6 @@ RSpec.describe SdrConsumer do
   let(:message_contents) { { druid: 'druid:abc123', true_targets: ['Earthworks'] } }
 
   before do
-    allow(Settings.kafka).to receive_messages(
-      topic: 'testing_topic',
-      group_id: 'testing_group'
-    )
     allow(Honeybadger).to receive(:notify)
     allow(cocina_service).to receive(:fetch_record).and_return(record)
     allow(solr_service).to receive_messages(delete_by_id: true, update: true)


### PR DESCRIPTION
This changes the names of some config vars to match our racecar puppet profile and configures a new capistrano role to run indexing tasks.

Related puppet PR: https://github.com/sul-dlss/puppet/pull/12775/files