### PR TITLE
Just show the description for search results

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -183,10 +183,7 @@ class CatalogController < ApplicationController
     # SEARCH RESULTS FIELDS
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    config.add_index_field Settings.FIELDS.INDEX_YEAR
-    config.add_index_field Settings.FIELDS.CREATOR
     config.add_index_field Settings.FIELDS.DESCRIPTION, helper_method: :snippit
-    config.add_index_field Settings.FIELDS.PUBLISHER
 
     # ITEM VIEW FIELDS
     # solr fields to be displayed in the show (single result) view


### PR DESCRIPTION
Because we added several other fields into what's normally shown when
detailed results are enabled on the search results page, you could get
strange-looking entries with tons of years or publisher info.

This just keeps it to the actual description.
