### PR TITLE
Sort by recent items when there is no active query

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -322,7 +322,7 @@ class CatalogController < ApplicationController
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
-    config.add_sort_field 'score desc, dct_title_sort asc', label: 'relevance'
+    config.add_sort_field "score desc, #{Settings.FIELDS.INDEX_YEAR} desc, dct_title_sort asc", label: 'relevance'
     config.add_sort_field "#{Settings.FIELDS.INDEX_YEAR} desc, dct_title_sort asc", label: 'year'
     config.add_sort_field 'dct_title_sort asc', label: 'title'
     config.add_sort_field "#{Settings.FIELDS.MODIFIED} asc", label: 'Layer modified date (for API use only)', if: false


### PR DESCRIPTION
Our 'relevance' sort uses the search term (if there is one), then
the title. Because of this, when there is no query, you just get things
that are alphabetically first, which is mostly items in other languages
due to unicode order of precedence, like our Gaihozu index maps.

This way, the first thing you see if you don't put in a query is the
items that have more recent dates, which are more immediately useful.
