### PR TITLE
Display recently added items as a block

### DIFF
--- a/app/components/recently_added_list_component.html.erb
+++ b/app/components/recently_added_list_component.html.erb
@@ -2,16 +2,22 @@
   <%= helpers.geoblacklight_icon(type) %>
   <span class="ms-1"><%= t("earthworks.home.#{type}.header") %></span>
 </h1>
+
 <div class="home-tab">
   <div class="mb-1">
     <%= t("earthworks.home.#{type}.description_html", sets: number_with_delimiter(count)) %>
   </div>
+
   <h2 class="h4 mt-3">Recently added</h2>
+
   <ul class="list-unstyled">
     <% docs.each do | doc | %>
-      <li class="my-1"><%= link_to doc['dct_title_s'], solr_document_path(doc['id']) %></li>
+      <li class="my-1">
+        <%= link_to doc['dct_title_s'], solr_document_path(doc['id']), class: 'd-block' %>
+      </li>
     <% end %>
   </ul>
+
   <div class="d-flex justify-content-end">
     <%= link_to t("earthworks.home.#{type}.button_text"), search_catalog_path("f[#{field}][]": term), class: 'btn btn-outline-primary' %>
   </div>


### PR DESCRIPTION
So that on a narrow screen, where the link wraps to two lines, the focus ring circles the whole thing

Before

<img width="211" height="249" alt="Screenshot 2025-12-04 at 1 33 09 PM" src="https://github.com/user-attachments/assets/458a6cf0-e71e-4258-828e-5410293a1c94" />

After
<img width="218" height="255" alt="Screenshot 2025-12-04 at 1 33 01 PM" src="https://github.com/user-attachments/assets/3450ed56-1fdc-4997-8c4a-1a40876c51a6" />

