### PR TITLE
Use an appropriate solr schema version.

### DIFF
--- a/config/solr_configs/schema.xml
+++ b/config/solr_configs/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema name="geoblacklight-schema" version="4.0">
+<schema name="geoblacklight-schema" version="1.6">
   <uniqueKey>id</uniqueKey>
   <fields>
     <field name="_version_" type="long"   stored="true" indexed="true"/>


### PR DESCRIPTION
I don't know where `4.0` came from, but `1.7` is current (with some breaking changes).