### PR TITLE
Remove `enableRemoteStreaming` configuration

### DIFF
--- a/config/solr_configs/solrconfig.xml
+++ b/config/solr_configs/solrconfig.xml
@@ -88,7 +88,7 @@
   </query>
 
   <requestDispatcher handleSelect="false">
-    <requestParsers enableRemoteStreaming="true" multipartUploadLimitInKB="2048000" formdataUploadLimitInKB="2048" addHttpRequestToContext="false"/>
+    <requestParsers multipartUploadLimitInKB="2048000" formdataUploadLimitInKB="2048" addHttpRequestToContext="false"/>
     <httpCaching never304="true"/>
    </requestDispatcher>
 


### PR DESCRIPTION
This is no longer the default (as of Solr 7.x) and if we're not using it, we should turn it off.