### PR TITLE
Stop using the skypack CDN

### DIFF
--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -65,9 +65,9 @@
     >
 
     <!-- viewer styles (non-render-blocking; deferred) -->
-    <%= preload_link_tag "https://cdn.skypack.dev/leaflet@1.9.4/dist/leaflet.css", as: "style", onload: "this.onload=null;this.rel='stylesheet'" %>
+    <%= preload_link_tag "https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.css", as: "style", onload: "this.onload=null;this.rel='stylesheet'" %>
     <%= preload_link_tag "https://cdn.jsdelivr.net/npm/leaflet-fullscreen@1.0.2/dist/leaflet.fullscreen.css", as: "style", onload: "this.onload=null;this.rel='stylesheet'" %>
-    <%= preload_link_tag "https://cdn.skypack.dev/ol@8.1.0/ol.css", as: "style", onload: "this.onload=null;this.rel='stylesheet'" %>
+    <%= preload_link_tag "https://cdn.jsdelivr.net/npm/ol@8.1.0/ol.css", as: "style", onload: "this.onload=null;this.rel='stylesheet'" %>
 
     <!-- main app styles -->
     <%= stylesheet_link_tag "geoblacklight", media: "all", "data-turbo-track": "reload" %>
@@ -84,7 +84,7 @@
       <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
       <%= javascript_include_tag "blacklight/blacklight", type: 'module' %>
       <script type="module">
-        import githubAutoCompleteElement from 'https://cdn.skypack.dev/@github/auto-complete-element';
+        import githubAutoCompleteElement from 'https://cdn.jsdelivr.net/npm/@github/auto-complete-element@3.8.0/+esm';
       </script>
     <% end %>
 

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,12 +6,12 @@ pin '@hotwired/stimulus-loading', to: 'stimulus-loading.js', preload: true
 pin '@hotwired/turbo-rails', to: 'turbo.min.js', preload: true
 
 # Bootstrap
-pin '@popperjs/core', to: 'https://cdn.skypack.dev/@popperjs/core@2.11.8'
-pin 'bootstrap', to: 'https://cdn.skypack.dev/bootstrap@5.3.3'
+pin '@popperjs/core', to: 'https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8'
+pin 'bootstrap', to: 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/+esm'
 
 # Blacklight
-pin 'blacklight', to: 'https://cdn.skypack.dev/blacklight-frontend@8.4.0/dist/blacklight.js'
-pin '@github/auto-complete-element', to: 'https://cdn.skypack.dev/@github/auto-complete-element'
+pin 'blacklight', to: 'https://cdn.jsdelivr.net/npm/blacklight-frontend@8.4.0/app/assets/javascripts/blacklight/blacklight.js'
+pin '@github/auto-complete-element', to: 'https://cdn.jsdelivr.net/npm/@github/auto-complete-element@3.8.0/+esm'
 
 # EarthWorks
 pin_all_from 'app/javascript/controllers', under: 'controllers'


### PR DESCRIPTION
It's not being maintained.

Note that there are still some references coming from Geoblacklight,
which will need to be handled separately.
