### PR TITLE
fix alignment of show page icons with text

### DIFF
--- a/app/assets/stylesheets/earthworks.css
+++ b/app/assets/stylesheets/earthworks.css
@@ -24,6 +24,10 @@ header .container,
   line-height: 1.125rem;
 }
 
+.show-document .header-icons .label {
+  vertical-align: middle;
+}
+
 .header-icons .blacklight-icons,
 .header-icons .blacklight-icons svg {
   height: 0.875rem;

--- a/app/components/header_icons_component.html.erb
+++ b/app/components/header_icons_component.html.erb
@@ -3,7 +3,7 @@
     <% icon, label = get_icon(field) %>
     <% if label %>
       <%= icon %>
-      <span class="me-1"><%= label.upcase %></span>
+      <span class="me-1 label"><%= label.upcase %></span>
     <% end %>
   <% end %>
 </div>


### PR DESCRIPTION
before:
<img width="346" height="131" alt="Screenshot 2026-01-27 at 3 50 33 PM" src="https://github.com/user-attachments/assets/068268a5-4ae9-43b8-9c76-f48b2643e6b3" />

After:
<img width="638" height="125" alt="Screenshot 2026-01-27 at 3 50 22 PM" src="https://github.com/user-attachments/assets/de22abb4-c6d2-4656-a3d5-facb6b7aebd5" />
