### PR TITLE
move more-info bottom padding to right element

### DIFF
--- a/app/components/search_result_component.html.erb
+++ b/app/components/search_result_component.html.erb
@@ -21,8 +21,8 @@
       </div>
     <% end %>
   <% end %>
-  <div class='more-info-area border-bottom px-2 pb-2'>
-    <div id="doc-<%= @document.id %>-fields-collapse" class='collapse description' data-controller="description">
+  <div class='more-info-area border-bottom px-2'>
+    <div id="doc-<%= @document.id %>-fields-collapse" class='collapse description pb-2' data-controller="description">
       <small itemprop="description">
         <%= index_fields_display %>
       </small>


### PR DESCRIPTION
Currently there is this weird bit of extra padding on the search results which I am pretty sure is there so that the expanded view has space between the line and the text. This moves the padding to the correct element so there is symmetry to our results
Before:
<img width="550" height="364" alt="Screenshot 2026-01-27 at 5 13 24 PM" src="https://github.com/user-attachments/assets/ff8d4e47-c014-4eda-a23c-33285aba859a" />
After:
<img width="573" height="422" alt="Screenshot 2026-01-27 at 5 14 10 PM" src="https://github.com/user-attachments/assets/eea109fb-a6cf-43ec-b18c-945129e03b08" />

<img width="537" height="386" alt="Screenshot 2026-01-27 at 5 14 27 PM" src="https://github.com/user-attachments/assets/b05f5f22-225d-4c44-b676-19b453345d36" />
