### PR TITLE
Rearrange record show page element order

### DIFF
--- a/app/components/document_component.html.erb
+++ b/app/components/document_component.html.erb
@@ -25,6 +25,17 @@
           <%= render Geoblacklight::DisplayNoteComponent.new(display_note: display_note) %>
         <% end %>
         <%= embed %>
+        <% if (@document.image? || @document.item_viewer.iiif) && !@document[Settings.FIELDS[:GEOREFERENCED]] %>
+          <%= render AlertComponent.new(type: 'info', body: t('earthworks.show.no_georeference_message')) %>
+        <% end %>
+        <div id="viewer-container">
+          <%= render Geoblacklight::ViewerHelpTextComponent.new('viewer_protocol', @document.viewer_protocol) %>
+          <%= render Geoblacklight::IndexMapLegendComponent.new(document: @document) %>
+          <%= render Geoblacklight::ItemMapViewerComponent.new(document: @document) %>
+          <%= render Geoblacklight::IiifDragDropComponent.new(document: @document) %>
+        </div>
+        <%= render Geoblacklight::AttributeTableComponent.new(document: @document) %>
+        <%= render Geoblacklight::IndexMapInspectComponent.new(document: @document) %>
         <%= content %>
         <%= metadata %>
         <% metadata_sections.each do |section| %>
@@ -35,22 +46,8 @@
           <%= partial %>
         <% end %>
       </div>
-  
       <%= thumbnail %>
     <% end %>
     <%= footer %>
   <% end %>
-  <div class="col-lg-6">
-    <% if (@document.image? || @document.item_viewer.iiif) && !@document[Settings.FIELDS[:GEOREFERENCED]] %>
-      <%= render AlertComponent.new(type: 'info', body: t('earthworks.show.no_georeference_message')) %>
-    <% end %>
-    <div id="viewer-container">
-      <%= render Geoblacklight::ViewerHelpTextComponent.new('viewer_protocol', @document.viewer_protocol) %>
-      <%= render Geoblacklight::IndexMapLegendComponent.new(document: @document) %>
-      <%= render Geoblacklight::ItemMapViewerComponent.new(document: @document) %>
-      <%= render Geoblacklight::IiifDragDropComponent.new(document: @document) %>
-    </div>
-    <%= render Geoblacklight::AttributeTableComponent.new(document: @document) %>
-    <%= render Geoblacklight::IndexMapInspectComponent.new(document: @document) %>
-  </div>
 </div>

--- a/app/components/document_component.rb
+++ b/app/components/document_component.rb
@@ -6,7 +6,6 @@ class DocumentComponent < Geoblacklight::DocumentComponent
       @classes,
       helpers.render_document_class(@document),
       'document',
-      'col-lg-6',
       ("document-position-#{@counter}" if @counter)
     ].compact.flatten
   end

--- a/app/helpers/earthworks_blacklight_helper.rb
+++ b/app/helpers/earthworks_blacklight_helper.rb
@@ -3,12 +3,12 @@ module EarthworksBlacklightHelper
 
   # Blacklight override for show main content
   def show_content_classes
-    'col-lg-10 show-document'
+    'col-lg-9 show-document'
   end
 
   # Blacklight override for show page sidebar
   def show_sidebar_classes
-    'page-sidebar col-lg-2'
+    'page-sidebar col-lg-3'
   end
 
   # Blacklight override for search results

--- a/app/views/layouts/catalog_result.html.erb
+++ b/app/views/layouts/catalog_result.html.erb
@@ -2,13 +2,12 @@
 <%= render Blacklight::Document::PageHeaderComponent.new(document: @document, search_context: @search_context, search_session: search_session) %>
 <% end %>
 <% content_for(:content) do %>
-  <aside class="<%= show_sidebar_classes %>" aria-label="<%= t('.aria.sidebar') %>">
-    <%= content_for(:sidebar) %>
-  </aside>
-
   <section class="<%= show_content_classes %>">
     <%= yield %>
   </section>
+  <aside class="<%= show_sidebar_classes %>" aria-label="<%= t('.aria.sidebar') %>">
+    <%= content_for(:sidebar) %>
+  </aside>
 <% end %>
 
 <%= render template: "layouts/blacklight/base" %>


### PR DESCRIPTION
This reorganizes the record detail page to look similar to Searchworks.
The record action sidebar is on the right, and the record details take
up a larger space on the left, including the map preview.
