### PR TITLE
Remove rack-mini-profiler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,9 +28,6 @@ end
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 4.1.0'
-  # Display performance information such as SQL time and flame graphs for each request in your browser.
-  # Can be configured to work on production as well see: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
-  gem 'rack-mini-profiler', '~> 2.0'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -426,8 +426,6 @@ GEM
     rack-cors (3.0.0)
       logger
       rack (>= 3.0.14)
-    rack-mini-profiler (2.3.4)
-      rack (>= 1.2.0)
     rack-proxy (0.8.2)
       rack
     rack-session (2.1.2)
@@ -740,7 +738,6 @@ DEPENDENCIES
   puma (>= 6)
   racecar (~> 2.12)
   rack-cors (~> 3.0)
-  rack-mini-profiler (~> 2.0)
   rails (~> 8.1.0)
   recaptcha (>= 5.4.1)
   redis (~> 5.0)


### PR DESCRIPTION
Rails no longer installs this by default.  I don't think we're using it