### PR TITLE
Ensure dct_format_s is mapped to only a single value

### DIFF
--- a/app/services/cocina_to_solr_mapper.rb
+++ b/app/services/cocina_to_solr_mapper.rb
@@ -84,8 +84,9 @@ class CocinaToSolrMapper
     TranslationMap.new('geo_resource_type').translate(record.all_forms.map(&:to_s) + record.subject_topics)
   end
 
+  # @return [String]
   def map_format
-    TranslationMap.new('geo_format').translate(record.all_forms.map(&:to_s) + record.file_mime_types)
+    TranslationMap.new('geo_format').translate(record.all_forms.map(&:to_s) + record.file_mime_types).first
   end
 
   def map_source

--- a/spec/services/cocina_to_solr_mapper_spec.rb
+++ b/spec/services/cocina_to_solr_mapper_spec.rb
@@ -71,6 +71,16 @@ RSpec.describe CocinaToSolrMapper do
       end
     end
 
+    context 'when all_forms returns multiple formats' do
+      before do
+        allow(record).to receive(:all_forms).and_return(%w[Shapefile PMTiles])
+      end
+
+      it 'maps dct_format_s to only a single value' do
+        expect(doc['dct_format_s']).to eq 'Shapefile'
+      end
+    end
+
     context 'with IIIF georeference annotations' do
       let(:files) do
         [instance_double(CocinaDisplay::Structural::File, mime_type: 'application/json', use: 'georeference',


### PR DESCRIPTION
So that the indexer is compliant with the Aardvark spec: https://opengeometadata.org/ogm-aardvark/\#format

Fixes #1663 