### PR TITLE
Remove cron and rake task for rack attack cache

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -21,10 +21,6 @@
 
 set :output, 'log/cron.log'
 
-every '0 3 * * *', roles: %i[app] do # daily at 3 am
-  rake 'earthworks:clear_rack_attack_cache'
-end
-
 every 1.day, at: '1:04 am', roles: %i[cron] do
   rake 'rake earthworks:clear_download_cache_stale_files'
 end

--- a/lib/tasks/earthworks.rake
+++ b/lib/tasks/earthworks.rake
@@ -62,19 +62,6 @@ namespace :earthworks do
     User.delete(old_bookmarkless_guest_users_ids)
   end
 
-  desc 'Clear Rack::Attack cache'
-  task clear_rack_attack_cache: [:environment] do
-    if Settings.THROTTLE_TRAFFIC
-      # This functionality will be available as Rack::Attack.reset! but as of 6.2.2 this is not released
-      store = Rack::Attack.cache.store
-      if store.respond_to?(:delete_matched)
-        store.delete_matched("#{Rack::Attack.cache.prefix}*")
-      else
-        puts "Error Clearing Rack::Attack cache. Store #{store.class.name} does not respond to #delete_matched"
-      end
-    end
-  end
-
   desc 'Clean earthworks stale download files'
   task clear_download_cache_stale_files: [:environment] do
     # Commented line below is for testing purposes, it will just list the files that


### PR DESCRIPTION
We aren't using rack-attack anymore.
