### PR TITLE
Add a wrapper div to the Also available at section

### DIFF
--- a/app/components/also_available_component.html.erb
+++ b/app/components/also_available_component.html.erb
@@ -1,6 +1,8 @@
-<h2 class="h4">Also available at</h2>
-<ul class="list-unstyled">
-    <% also_available_links.each do |label, url| %>
-        <li><%= link_to label, url %></li>
-    <% end %>
-</ul>
+<div>
+  <h2 class="h4">Also available at</h2>
+  <ul class="list-unstyled">
+      <% also_available_links.each do |label, url| %>
+          <li><%= link_to label, url %></li>
+      <% end %>
+  </ul>
+</div>

--- a/app/components/document/sidebar_component.rb
+++ b/app/components/document/sidebar_component.rb
@@ -11,9 +11,9 @@ module Document
         DownloadLinksComponent.new(document:),
         ShowToolsComponent.new(document:),
         AccessComponent.new(document:),
-        AlsoAvailableComponent.new(document:),
         'relations_container',
-        Blacklight::Document::MoreLikeThisComponent.new(document:)
+        Blacklight::Document::MoreLikeThisComponent.new(document:),
+        AlsoAvailableComponent.new(document:)
       ]
     end
   end


### PR DESCRIPTION
This prevents the sidebar spacers from showing up in the middle of this content

Fixes #1682