### PR TITLE
Remove 'tmp/opengeometadata' from linked_dirs

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -29,8 +29,7 @@ set :linked_files,
 
 # Default value for linked_dirs is []
 set :linked_dirs,
-    %w[config/settings log tmp/pids tmp/cache tmp/sockets tmp/opengeometadata vendor/bundle public/system
-       public/sitemaps]
+    %w[config/settings log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system public/sitemaps]
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }


### PR DESCRIPTION
The data is stored in /var/cache/earthworks/opengeometadata now