### PR TITLE
Disable image processing

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,5 +32,7 @@ module Earthworks
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.active_storage.variant_processor = :disabled
   end
 end


### PR DESCRIPTION
prevents a warning:

```
Generating image variants require the image_processing gem. Please add `gem "image_processing", "~> 1.2"` to your Gemfile or set `config.active_storage.variant_processor = :disabled`.
```