### PR TITLE
Remove GeoCombine pin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,6 @@ gem 'honeybadger'
 gem 'blacklight_dynamic_sitemap', '~> 0.3'
 gem 'newrelic_rpm'
 gem 'redis', '~> 5.0'
-gem 'geo_combine', '>= 0.9' # For OpenGeoMetadata indexing
 gem 'sidekiq', '~> 8.0'
 gem 'whenever', require: false
 gem 'recaptcha', '>= 5.4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,7 +219,7 @@ GEM
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     ffi (1.17.4-x86_64-linux-musl)
-    geo_combine (0.9.2)
+    geo_combine (0.10.0)
       activesupport
       faraday-net_http_persistent (~> 2.0)
       faraday-retry (~> 2.2)
@@ -688,7 +688,6 @@ DEPENDENCIES
   dotenv
   ed25519 (~> 1.3)
   factory_bot_rails
-  geo_combine (>= 0.9)
   geoblacklight (= 6.0.0.pre.alpha.2)
   global_alerts
   honeybadger


### PR DESCRIPTION
We can just use the version that GeoBlacklight provides.
