### PR TITLE
Remove the background color on the relationships card cap

### DIFF
--- a/app/assets/stylesheets/earthworks.css
+++ b/app/assets/stylesheets/earthworks.css
@@ -72,6 +72,8 @@ header .container,
     --bs-border-width: 0;
     --bs-card-cap-padding-y: 0px;
     --bs-card-cap-padding-x: 0px;
+    --bs-card-bg: transparent;
+    --bs-card-cap-bg: transparent;
 
     .list-group {
       --bs-list-group-bg: var(--stanford-fog-light);


### PR DESCRIPTION
This was almost but not quite the same as the sidebar

Visibile on http://localhost:3000/catalog/nyu_2451_34636