### PR TITLE
Display file format as simple text in downloads

### DIFF
--- a/app/assets/stylesheets/earthworks.css
+++ b/app/assets/stylesheets/earthworks.css
@@ -386,13 +386,6 @@ body {
   margin-top: 1rem;
 }
 
-/* Download sidebar */
-.downloads .badge {
-  float: none;
-  margin-inline-start: 0.5em;
-  vertical-align: top;
-}
-
 /* Global alert styles */
 .global-alert {
   --bs-alert-margin-bottom: 0;

--- a/app/components/document/download_link_component.html.erb
+++ b/app/components/document/download_link_component.html.erb
@@ -1,6 +1,6 @@
 <li class="download">
   <%= link_to url, data: @data do %>
-  <p class="title"><%= title %></p>
-  <% if file_type.present? %><span class="badge text-bg-dark"><%= file_type %></span><% end %>
+  <span class="title"><%= title %></span>
+  <% if file_type.present? %><span class="format">(<%= file_type %>)</span><% end %>
   <% end %>
 </li>


### PR DESCRIPTION
The badges don't play nice with our sidebar styling, and end up
looking weird when the file name is long.
