### PR TITLE
Use the same layout & width as DataWorks

### DIFF
--- a/app/assets/stylesheets/earthworks.css
+++ b/app/assets/stylesheets/earthworks.css
@@ -4,6 +4,20 @@
   --stanford-palo-alto-rgb: 23, 94, 84;
 }
 
+/* Below lg, match the gap between show-document and the sidebar to the metadata section gap. */
+@media (max-width: 991.98px) {
+  .blacklight-catalog-show .page-sidebar {
+    margin-top: 2rem;
+  }
+}
+
+/* Above xl, widen the gap between the record and the sidebar on the show view. */
+@media (min-width: 1400px) {
+  .blacklight-catalog-show .show-document {
+    padding-right: 6rem;
+  }
+}
+
 .header-icons {
   color: var(--stanford-60-black);
   font-size: 0.875rem;

--- a/app/assets/stylesheets/earthworks.css
+++ b/app/assets/stylesheets/earthworks.css
@@ -4,20 +4,6 @@
   --stanford-palo-alto-rgb: 23, 94, 84;
 }
 
-/* Selects both #main-content and navbar containers */
-#main-container,
-.navbar-search > *,
-header .container,
-#feedback .container,
-#pre-footer .container,
-#su-footer .container {
-  max-width: 1600px;
-
-  @media (min-width: 575.98px) {
-    padding-inline: 60px;
-  }
-}
-
 .header-icons {
   color: var(--stanford-60-black);
   font-size: 0.875rem;

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -47,6 +47,9 @@ class CatalogController < ApplicationController
       q: "{!raw f=#{field_config.id} v=$id}"
     }
 
+    # Turn off advanced search
+    config.advanced_search.enabled = false
+
     # GeoBlacklight Defaults
     # * Adds the "map" split view for catalog#index
     config.view.split(partials: ['index'])

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -24,7 +24,7 @@ class CatalogController < ApplicationController
     end
   end
 
-  configure_blacklight do |config| # rubocop:disable Metrics/BlockLength
+  configure_blacklight do |config|
     field_config = Geoblacklight.configuration.fields
     # Ensures that JSON representations of Solr Documents can be retrieved using
     # the path /catalog/:id/raw
@@ -46,11 +46,6 @@ class CatalogController < ApplicationController
       qt: 'document',
       q: "{!raw f=#{field_config.id} v=$id}"
     }
-
-    # When set to true, Blacklight uses container-fluid as the layout container
-    config.full_width_layout = true
-
-    config.advanced_search.enabled = false
 
     # GeoBlacklight Defaults
     # * Adds the "map" split view for catalog#index


### PR DESCRIPTION
In https://github.com/sul-dlss/earthworks/commit/9c90b81b82adb65abd58f1974e23664858a58ab3, we changed the layout to give more breathing room to the map and sidebar.

Now that we've rearranged the UI to match Searchworks and Dataworks, and with some of the changes in GBL6, this is no longer necessary – there's plenty of space for the viewer and metadata to breathe.

This reverts https://github.com/sul-dlss/earthworks/commit/9c90b81b82adb65abd58f1974e23664858a58ab3 and makes the arrangement of the columns on the show page match our other platforms.