### PR TITLE
Make the RecentlyAddedComponent link to a search sorted that way

### DIFF
--- a/app/components/recently_added_list_component.html.erb
+++ b/app/components/recently_added_list_component.html.erb
@@ -19,6 +19,6 @@
   </ul>
 
   <div class="d-flex justify-content-end">
-    <%= link_to t("earthworks.home.#{type}.button_text"), search_catalog_path("f[#{field}][]": term), class: 'btn btn-outline-primary' %>
+    <%= link_to t("earthworks.home.#{type}.button_text"), search_url, class: 'btn btn-outline-primary' %>
   </div>
 </div>

--- a/app/components/recently_added_list_component.rb
+++ b/app/components/recently_added_list_component.rb
@@ -26,6 +26,10 @@ class RecentlyAddedListComponent < ViewComponent::Base
     }
   end
 
+  def search_url
+    helpers.search_catalog_path("f[#{@field}][]": @term, sort: @sort)
+  end
+
   def results
     solr = RSolr.connect url: Blacklight.connection_config[:url]
     @results = solr.get 'select', params: search_params

--- a/spec/components/recently_added_list_component_spec.rb
+++ b/spec/components/recently_added_list_component_spec.rb
@@ -10,4 +10,11 @@ RSpec.describe RecentlyAddedListComponent, type: :component do
   it 'renders the correct number of items by default' do
     expect(rendered_component).to have_css('li', count: 4)
   end
+
+  it 'renders a link to the search results page' do
+    expect(rendered_component).to have_link(
+      'Browse all datasets',
+      href: '/catalog?f%5Bgbl_resourceClass_sm%5D%5B%5D=Datasets&sort=gbl_mdModified_dt+desc'
+    )
+  end
 end


### PR DESCRIPTION
Now that we have a sort option for recently updated/modified, we
can make the links on the homepage go to a search that is also
sorted that way, which matches the items shown.
