### PR TITLE
Process a batch of messages from kafka

### DIFF
--- a/app/consumers/sdr_consumer.rb
+++ b/app/consumers/sdr_consumer.rb
@@ -1,5 +1,8 @@
 # Harvest items published from SDR for indexing
 class SdrConsumer < Racecar::Consumer
+  RECORD_NOT_FETCHED = Object.new.freeze
+  private_constant :RECORD_NOT_FETCHED
+
   subscribes_to Settings.indexer_topic
   self.group_id = Settings.indexer_group
 
@@ -16,17 +19,35 @@ class SdrConsumer < Racecar::Consumer
     @solr_service = solr_service
   end
 
-  # Process a single message from the Kafka queue; key is the druid
-  def process(message)
-    @druid = message.key.delete_prefix('druid:')
-    @change = JSON.parse(message.value) if message.value.present?
-    delete? ? process_delete : process_update
+  # Process a batch of messages from a single Kafka partition
+  def process_batch(messages)
+    pending_deletes = []
+
+    messages.each do |message|
+      prepare(message)
+      if delete?
+        pending_deletes << @druid
+      else
+        process_deletes(pending_deletes)
+        pending_deletes.clear
+        process_update
+      end
+    end
+
+    process_deletes(pending_deletes)
   rescue StandardError => e
     Honeybadger.notify(e)
     raise e
   end
 
   private
+
+  # Set the state for a single message; key is the druid
+  def prepare(message)
+    @druid = message.key.delete_prefix('druid:')
+    @change = message.value.present? ? JSON.parse(message.value) : nil
+    @record = RECORD_NOT_FETCHED
+  end
 
   # Determine if the item should be removed from the index
   def delete?
@@ -57,12 +78,13 @@ class SdrConsumer < Racecar::Consumer
 
   # Public cocina record for the item
   def record
-    @cocina_service.fetch_record(@druid)
+    @record = @cocina_service.fetch_record(@druid) if @record.equal?(RECORD_NOT_FETCHED)
+    @record
   end
 
-  # Remove item from the index
-  def process_delete
-    @solr_service.delete_by_id(@druid)
+  # Remove items from the index
+  def process_deletes(druids)
+    @solr_service.delete_by_ids(druids) if druids.any?
   end
 
   # Update item in the index

--- a/app/services/solr_service.rb
+++ b/app/services/solr_service.rb
@@ -7,6 +7,13 @@ class SolrService
     connection.delete_by_id(record_id, params: { commitWithin: Settings.solr_commit_within })
   end
 
+  # Delete records from the index by ID
+  def self.delete_by_ids(druids)
+    record_ids = druids.map { |druid| "stanford-#{druid}" }
+    Rails.logger.info "Deleting #{record_ids.size} Solr documents"
+    connection.delete_by_id(record_ids, params: { commitWithin: Settings.solr_commit_within })
+  end
+
   # Update a record in the index
   def self.update(record)
     Rails.logger.info "Updating Solr document: stanford-#{record.druid}"

--- a/spec/consumers/sdr_consumer_spec.rb
+++ b/spec/consumers/sdr_consumer_spec.rb
@@ -19,13 +19,18 @@ RSpec.describe SdrConsumer do
   before do
     allow(Honeybadger).to receive(:notify)
     allow(cocina_service).to receive(:fetch_record).and_return(record)
-    allow(solr_service).to receive_messages(delete_by_id: true, update: true)
+    allow(solr_service).to receive_messages(delete_by_ids: true, update: true)
   end
 
-  describe '#process' do
+  describe '#process_batch' do
     it 'executes an update' do
       expect(solr_service).to receive(:update).with(record)
-      consumer.process(message)
+      consumer.process_batch([message])
+    end
+
+    it 'fetches the Cocina record once per message' do
+      expect(cocina_service).to receive(:fetch_record).once.and_return(record)
+      consumer.process_batch([message])
     end
 
     context 'with varying spelling of target names' do
@@ -33,7 +38,7 @@ RSpec.describe SdrConsumer do
 
       it 'counts as valid' do
         expect(solr_service).to receive(:update).with(record)
-        consumer.process(message)
+        consumer.process_batch([message])
       end
     end
 
@@ -41,8 +46,8 @@ RSpec.describe SdrConsumer do
       let(:message_contents) { nil }
 
       it 'executes a delete' do
-        expect(solr_service).to receive(:delete_by_id).with('abc123')
-        consumer.process(message)
+        expect(solr_service).to receive(:delete_by_ids).with(['abc123'])
+        consumer.process_batch([message])
       end
     end
 
@@ -55,8 +60,8 @@ RSpec.describe SdrConsumer do
       end
 
       it 'executes a delete' do
-        expect(solr_service).to receive(:delete_by_id).with('abc123')
-        consumer.process(message)
+        expect(solr_service).to receive(:delete_by_ids).with(['abc123'])
+        consumer.process_batch([message])
       end
     end
 
@@ -69,8 +74,8 @@ RSpec.describe SdrConsumer do
       end
 
       it 'executes a delete' do
-        expect(solr_service).to receive(:delete_by_id).with('abc123')
-        consumer.process(message)
+        expect(solr_service).to receive(:delete_by_ids).with(['abc123'])
+        consumer.process_batch([message])
       end
     end
 
@@ -80,8 +85,8 @@ RSpec.describe SdrConsumer do
       end
 
       it 'executes a delete' do
-        expect(solr_service).to receive(:delete_by_id).with('abc123')
-        consumer.process(message)
+        expect(solr_service).to receive(:delete_by_ids).with(['abc123'])
+        consumer.process_batch([message])
       end
     end
 
@@ -89,8 +94,8 @@ RSpec.describe SdrConsumer do
       let(:record) { instance_double(CocinaDisplay::CocinaRecord, folio_hrid: 'a12345') }
 
       it 'executes a delete' do
-        expect(solr_service).to receive(:delete_by_id).with('abc123')
-        consumer.process(message)
+        expect(solr_service).to receive(:delete_by_ids).with(['abc123'])
+        consumer.process_batch([message])
       end
     end
 
@@ -108,7 +113,7 @@ RSpec.describe SdrConsumer do
 
       it 'executes an update' do
         expect(solr_service).to receive(:update).with(record)
-        consumer.process(message)
+        consumer.process_batch([message])
       end
     end
 
@@ -116,8 +121,44 @@ RSpec.describe SdrConsumer do
       let(:message_contents) { { druid: 'druid:abc123', deleted_at: '2024-06-02T00:00:00Z' } }
 
       it 'executes a delete' do
-        expect(solr_service).to receive(:delete_by_id).with('abc123')
-        consumer.process(message)
+        expect(solr_service).to receive(:delete_by_ids).with(['abc123'])
+        consumer.process_batch([message])
+      end
+    end
+
+    context 'with multiple deletes' do
+      it 'deletes them in one Solr request' do
+        messages = %w[abc123 def456 ghi789].map do |druid|
+          instance_double(Racecar::Message, key: "druid:#{druid}", value: nil)
+        end
+
+        expect(solr_service).to receive(:delete_by_ids).with(%w[abc123 def456 ghi789])
+        consumer.process_batch(messages)
+      end
+    end
+
+    context 'when an update occurs between deletes' do
+      it 'flushes deletes around the update to preserve order' do
+        first_delete = instance_double(Racecar::Message, key: 'druid:abc123', value: nil)
+        update = instance_double(Racecar::Message, key: 'druid:def456', value: message_contents.to_json)
+        last_delete = instance_double(Racecar::Message, key: 'druid:ghi789', value: nil)
+
+        expect(solr_service).to receive(:delete_by_ids).with(['abc123']).ordered
+        expect(solr_service).to receive(:update).with(record).ordered
+        expect(solr_service).to receive(:delete_by_ids).with(['ghi789']).ordered
+
+        consumer.process_batch([first_delete, update, last_delete])
+      end
+    end
+
+    context 'with a blank message after an update' do
+      it 'does not reuse the preceding message contents' do
+        blank_message = instance_double(Racecar::Message, key: 'druid:def456', value: nil)
+
+        expect(solr_service).to receive(:update).with(record).ordered
+        expect(solr_service).to receive(:delete_by_ids).with(['def456']).ordered
+
+        consumer.process_batch([message, blank_message])
       end
     end
 
@@ -128,7 +169,7 @@ RSpec.describe SdrConsumer do
 
       it 'notifies Honeybadger' do
         expect(Honeybadger).to receive(:notify).with(instance_of(StandardError))
-        expect { consumer.process(message) }.to raise_error(StandardError)
+        expect { consumer.process_batch([message]) }.to raise_error(StandardError)
       end
     end
   end

--- a/spec/services/solr_service_spec.rb
+++ b/spec/services/solr_service_spec.rb
@@ -16,4 +16,21 @@ RSpec.describe SolrService do
       described_class.delete_by_id('bc123df4567')
     end
   end
+
+  describe '.delete_by_ids' do
+    let(:connection) { instance_double(RSolr::Client) }
+
+    before do
+      allow(described_class).to receive(:connection).and_return(connection)
+    end
+
+    it 'deletes all IDs in a single request with commitWithin' do
+      expect(connection).to receive(:delete_by_id).with(
+        %w[stanford-bc123df4567 stanford-bd234fg5678],
+        params: { commitWithin: Settings.solr_commit_within }
+      )
+
+      described_class.delete_by_ids(%w[bc123df4567 bd234fg5678])
+    end
+  end
 end


### PR DESCRIPTION
This improves efficiency because we're not doing everything one at a time.  Since most of the messages are deletes, we bundle them in a batch and send them all at once.