### PR TITLE
Don't index IIIF manifest references for non-IIIF-viewable items

### DIFF
--- a/app/services/cocina_to_solr_mapper.rb
+++ b/app/services/cocina_to_solr_mapper.rb
@@ -105,7 +105,7 @@ class CocinaToSolrMapper
     # URLs
     refs['http://schema.org/url'] = record.purl_url
     refs['https://oembed.com'] = record.oembed_url(params: { hide_title: true })
-    refs['http://iiif.io/api/presentation#manifest'] = record.iiif_manifest_url
+    refs['http://iiif.io/api/presentation#manifest'] = record.iiif_manifest_url if iiif_viewable?
     refs['http://schema.org/thumbnailUrl'] = record.thumbnail_url
     refs['https://schema.org/relatedLink'] = record.searchworks_url
 
@@ -159,5 +159,10 @@ class CocinaToSolrMapper
     return true if record.files(use: 'georeference').any?
 
     false
+  end
+
+  # Object types with actually useful IIIF manifests
+  def iiif_viewable?
+    %(map image).include?(record.content_type)
   end
 end

--- a/spec/services/cocina_to_solr_mapper_spec.rb
+++ b/spec/services/cocina_to_solr_mapper_spec.rb
@@ -58,6 +58,20 @@ RSpec.describe CocinaToSolrMapper do
       expect(doc['gbl_georeferenced_b']).to be true
     end
 
+    it 'does not map the iiif manifest url' do
+      expect(references).not_to have_key('http://iiif.io/api/presentation#manifest')
+    end
+
+    context 'with a scanned map' do
+      before do
+        allow(record).to receive(:content_type).and_return('map')
+      end
+
+      it 'maps the iiif manifest url' do
+        expect(references['http://iiif.io/api/presentation#manifest']).to eq 'https://purl.stanford.edu/abc12345678/iiif3/manifest'
+      end
+    end
+
     context 'with restricted access' do
       before do
         allow(record).to receive(:world_access?).and_return(false)


### PR DESCRIPTION
GIS data, documents, etc. don't have IIIF manifests that are
useful and worth surfacing.
