### PR TITLE
Don't automatically set georeferenced items as both Dataset and Map

### DIFF
--- a/app/services/cocina_to_solr_mapper.rb
+++ b/app/services/cocina_to_solr_mapper.rb
@@ -75,7 +75,6 @@ class CocinaToSolrMapper
   def map_resource_class
     res = TranslationMap.new('geo_resource_class')
                         .translate(record.all_forms.map(&:to_s) + record.genres + record.subject_genres)
-    res += %w[Maps Datasets] if @doc['gbl_georeferenced_b']
     res = ['Collections'] if record.collection?
     res << 'Other' if res.empty?
     res.uniq


### PR DESCRIPTION
Since we expanded the logic in #1710 to cover more items, it
resulted in vectors getting the "Map" resource class, which is
wrong. We don't need this hardcoded mapping any longer.
