### PR TITLE
Sort relevancy-ranked results by modified date instead of data year

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -294,7 +294,7 @@ class CatalogController < ApplicationController
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
-    config.add_sort_field "score desc, #{field_config.index_year} desc, dct_title_sort asc", label: 'relevance'
+    config.add_sort_field "score desc, #{field_config.modified} desc, dct_title_sort asc", label: 'relevance'
     config.add_sort_field "#{field_config.index_year} desc, dct_title_sort asc", label: 'year'
     config.add_sort_field 'dct_title_sort asc', label: 'title'
     config.add_sort_field "#{field_config.modified} desc", label: 'recently updated'


### PR DESCRIPTION
When there is no query active or the relevancy is tied, sort the
items with most recently modified first.

This helps get around weirdness in the data, like records with a
year of 2050 because they're predictive data, or records with
bizarre years like 9999. They'll still show up that way in the Date
facet, but it doesn't make sense to use those values to re-rank
relevancy queries.
