### PR TITLE
Upgrade blacklight-frontend to 9.0.0

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,7 +2,7 @@
 import "@hotwired/turbo-rails";
 import "bootstrap";
 import "@github/auto-complete-element";
-import "blacklight";
+import Blacklight from "blacklight-frontend";
 import "controllers/application";
 import "geoblacklight";
 import "controllers";

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -10,7 +10,6 @@ pin '@popperjs/core', to: 'https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8'
 pin 'bootstrap', to: 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/+esm'
 
 # Blacklight
-pin 'blacklight', to: 'https://cdn.jsdelivr.net/npm/blacklight-frontend@8.4.0/app/assets/javascripts/blacklight/blacklight.js'
 pin '@github/auto-complete-element', to: 'https://cdn.jsdelivr.net/npm/@github/auto-complete-element@3.8.0/+esm'
 
 # OpenLayers temporary fix


### PR DESCRIPTION
We were still using blacklight-frontend 8.4, which did not support facet filtering

Fixes #1737