### PR TITLE
Restore the translation mapping for format and theme

### DIFF
--- a/app/services/translation_map.rb
+++ b/app/services/translation_map.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: nil
+# frozen_string_literal: true
 
 class TranslationMap
   def initialize(name)
@@ -6,21 +6,20 @@ class TranslationMap
   end
 
   def translate(values)
-    Array(values).filter_map do |value|
-      match = nil
-      @map.each do |k, v|
-        if k.start_with?('/') && k.end_with?('/')
-          regex = Regexp.new(k[1..-2])
-          if value.to_s.match?(regex)
-            match = v
-            break
-          end
-        elsif k == value.to_s
-          match = v
-          break
-        end
-      end
-      match
-    end.uniq
+    Array(values).flat_map { |value| lookup(value) }.uniq
+  end
+
+  private
+
+  # A key may map to a single value or to a list of values; always return a list
+  def lookup(value)
+    _key, translation = @map.find { |key, _translation| match?(key, value.to_s) }
+    Array(translation)
+  end
+
+  def match?(key, value)
+    return value.match?(Regexp.new(key[1..-2])) if key.start_with?('/') && key.end_with?('/')
+
+    key == value
   end
 end

--- a/config/translation_maps/geo_format.yml
+++ b/config/translation_maps/geo_format.yml
@@ -1,6 +1,38 @@
-/.*[Gg]eo[Tt][Ii][Ff][Ff].*/: GeoTIFF
-/.*[Ss]hapefile.*/: Shapefile
-/.*[Gg]eo[Jj][Ss][Oo][Nn].*/: GeoJSON
-/.*[Kk][Mm][Ll].*/: KML
-/.*[Pp][Mm][Tt][Ii][Ll][Ee][Ss].*/: PMTiles
-/.*[Cc][Oo][Gg].*/: COG
+# Map values coming from cocina to OpenGeoMetadata "format" values
+# See: https://opengeometadata.org/ogm-aardvark/#format
+
+# Literals
+ArcGRID: ArcGRID
+CD-ROM: CD-ROM
+DEM: DEM
+DVD-ROM: DVD-ROM
+Feature Class: Feature Class
+Geodatabase: Geodatabase
+GeoJPEG: GeoJPEG
+GeoJSON: GeoJSON
+GeoPackage: GeoPackage
+GeoPDF: GeoPDF
+GeoTIFF: GeoTIFF
+JPEG: JPEG
+JPEG2000: JPEG2000
+KML: KML
+KMZ: KMZ
+LAS: LAS
+LAZ: LAZ
+Mixed: Mixed
+MrSID: MrSID
+PDF: PDF
+PMTiles: PMTiles
+PNG: PNG
+Pulsewaves: Pulsewaves
+Raster Dataset: Raster Dataset
+Shapefile: Shapefile
+SQLite Database: SQLite Database
+Tabular Data: Tabular Data
+TIFF: TIFF
+
+# MIME types (mainly for maps)
+image/jpeg: JPEG
+image/jp2: JPEG2000
+image/png: PNG
+application/pdf: PDF

--- a/config/translation_maps/geo_theme.yml
+++ b/config/translation_maps/geo_theme.yml
@@ -1,20 +1,79 @@
+# Map values coming from cocina to DCAT "theme" values
+# Related ISO 19115 topic categories are also mapped
+# See: https://opengeometadata.org/ogm-aardvark/#theme
+
+# 1:1 mapping
 Agriculture: Agriculture
-Biota: Biology
+Biology: Biology
 Boundaries: Boundaries
-ClimatologyMeteorologyAtmosphere: Climate
+Climate: Climate
 Economy: Economy
 Elevation: Elevation
 Environment: Environment
-Farming: Agriculture
-GeoscientificInformation: Geology
+Events: Events
+Geology: Geology
 Health: Health
-ImageryBaseMapsEarthCover: Imagery
-InlandWaters: Inland Waters
+Imagery: Imagery
+Inland Waters: Inland Waters
+Land Cover: Land Cover
 Location: Location
-IntelligenceMilitary: Military
+Military: Military
 Oceans: Oceans
-PlanningCadastre: Property
+Property: Property
 Society: Society
 Structure: Structure
 Transportation: Transportation
-UtilitiesCommunication: Utilities
+Utilities: Utilities
+
+# ISO 19115 topic categories mapping
+farming: Agriculture
+biota: Biology
+Biota: Biology
+boundaries: Boundaries
+Climatology, Meteorology and Atmosphere: Climate
+climatologyMeteorologyAtmosphere: Climate
+economy: Economy
+elevation: Elevation
+environment: Environment
+geoscientificInformation: Geology
+health: Health
+imageryBaseMapsEarthCover:
+  - Imagery
+  - Land Cover
+Imagery and Base Maps:
+  - Imagery
+  - Land Cover
+location: Location
+Landcover: Land Cover
+Land cover: Land Cover
+intelligenceMilitary: Military
+Intelligence and Military: Military
+oceans: Oceans
+planningCadastre: Property
+Planning and Cadastral: Property
+society: Society
+structure: Structure
+transportation: Transportation
+utilitiesCommunication: Utilities
+Utilities and Communication: Utilities
+
+# Misc. other Stanford data
+Aerial photographs: Imagery
+Aerial surveys: Imagery
+Bathymetric maps: Imagery
+California as an island--Maps: Imagery
+Composite map: Imagery
+Landsat satellites: Imagery
+Multibeam mapping: Imagery
+Nautical charts: Imagery
+Remote sensing: Imagery
+Remote sensing images: Imagery
+Satellite image maps: Imagery
+Coasts: Land Cover
+Forests: Land Cover
+Forest canopies: Land Cover
+Forests and forestry: Land Cover
+Hydrology: Land Cover
+Hydrography: Land Cover
+Landforms: Land Cover
+Vegetation mapping: Land Cover

--- a/spec/services/cocina_to_solr_mapper_spec.rb
+++ b/spec/services/cocina_to_solr_mapper_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe CocinaToSolrMapper do
     end
 
     it 'maps the subjects that are valid DCAT themes' do
-      expect(doc['dcat_theme_sm']).to eq ['Society']
+      expect(doc['dcat_theme_sm']).to eq ['Land Cover', 'Society', 'Imagery']
     end
 
     it 'maps the format' do

--- a/spec/services/translation_map_spec.rb
+++ b/spec/services/translation_map_spec.rb
@@ -11,7 +11,9 @@ RSpec.describe TranslationMap do
       'exact_key' => 'exact_value',
       '/^regex_.*$/' => 'regex_value',
       'other_key' => 'other_value',
-      '/foo/' => 'bar'
+      '/foo/' => 'bar',
+      'multi_key' => %w[first_value second_value],
+      '/^multi_regex/' => %w[regex_first regex_second]
     }
   end
 
@@ -44,6 +46,26 @@ RSpec.describe TranslationMap do
 
       it 'handles mid-string regex keys properly' do
         expect(translation_map.translate('my foo bar')).to eq(['bar'])
+      end
+    end
+
+    context 'with keys mapped to multiple values' do
+      it 'flattens the values of an exact match key' do
+        expect(translation_map.translate('multi_key')).to contain_exactly('first_value', 'second_value')
+      end
+
+      it 'flattens the values of a regex match key' do
+        expect(translation_map.translate('multi_regex_key')).to contain_exactly('regex_first', 'regex_second')
+      end
+
+      it 'flattens the values of every input into a single list' do
+        input = %w[exact_key multi_key]
+        expect(translation_map.translate(input)).to contain_exactly('exact_value', 'first_value', 'second_value')
+      end
+
+      it 'de-duplicates values shared between inputs' do
+        input = %w[multi_regex_a multi_regex_b]
+        expect(translation_map.translate(input)).to contain_exactly('regex_first', 'regex_second')
       end
     end
 
@@ -89,7 +111,19 @@ RSpec.describe TranslationMap do
       # Since we only stubbed 'test_map.yml', 'geo_theme' will load the real file
       map = described_class.new('geo_theme')
       expect(map.translate('Agriculture')).to eq(['Agriculture'])
-      expect(map.translate('Farming')).to eq(['Agriculture'])
+      expect(map.translate('intelligenceMilitary')).to eq(['Military'])
+    end
+
+    it 'flattens keys that map to more than one theme' do
+      map = described_class.new('geo_theme')
+      expect(map.translate('imageryBaseMapsEarthCover')).to contain_exactly('Imagery', 'Land Cover')
+      expect(map.translate('Imagery and Base Maps')).to contain_exactly('Imagery', 'Land Cover')
+    end
+
+    it 'flattens and de-duplicates across multiple inputs' do
+      map = described_class.new('geo_theme')
+      themes = map.translate(['imageryBaseMapsEarthCover', 'Land Cover', 'farming'])
+      expect(themes).to contain_exactly('Imagery', 'Land Cover', 'Agriculture')
     end
   end
 end


### PR DESCRIPTION
This ports config that was remaining in searchworks-traject-indexer,
so that we can delete it from there.
