### PR TITLE
Rename "recently added" to "recently updated"

### DIFF
--- a/app/components/recently_updated_list_component.html.erb
+++ b/app/components/recently_updated_list_component.html.erb
@@ -8,7 +8,7 @@
     <%= t("earthworks.home.#{type}.description_html", sets: number_with_delimiter(count)) %>
   </div>
 
-  <h2 class="h4 mt-3">Recently added</h2>
+  <h2 class="h4 mt-3"><%= t("earthworks.home.recently_updated") %></h2>
 
   <ul class="list-unstyled">
     <% docs.each do | doc | %>

--- a/app/components/recently_updated_list_component.rb
+++ b/app/components/recently_updated_list_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RecentlyAddedListComponent < ViewComponent::Base
+class RecentlyUpdatedListComponent < ViewComponent::Base
   attr_reader :count, :docs, :type, :field, :term
 
   def initialize(term:, additional_fq: '', rows: 4, field: 'gbl_resourceClass_sm')

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -7,9 +7,9 @@
       autocomplete_path: suggest_index_catalog_path
     ) %>
   <hr>
-  <%= render RecentlyAddedListComponent.new(term: 'Datasets') %>
+  <%= render RecentlyUpdatedListComponent.new(term: 'Datasets') %>
   <hr>
-  <%= render RecentlyAddedListComponent.new(term: 'Maps') %>
+  <%= render RecentlyUpdatedListComponent.new(term: 'Maps') %>
   </div>
   <div class="col-sm d-none d-md-block">
     <%= render(Geoblacklight::LocationLeafletMapComponent.new(page: 'home', geosearch: { dynamic: false })) %>

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -2,6 +2,7 @@ en:
   geoblacklight:
     home:
       headline: 'Discover and download GIS data and maps'
+      recently_updated: 'Recently updated'
     relations:
       member_of_ancestors: 'Item belongs to a collection'
       member_of_descendants: 'Collection items'

--- a/spec/components/recently_updated_list_component_spec.rb
+++ b/spec/components/recently_updated_list_component_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe RecentlyAddedListComponent, type: :component do
+RSpec.describe RecentlyUpdatedListComponent, type: :component do
   let(:term) { 'Datasets' }
   let(:component) { described_class.new(term:) }
   let(:rendered_component) { render_inline(component) }


### PR DESCRIPTION
Since it actually sorts based on modification date, so updated
things show up at the top.
