### PR TITLE
Don't skip items with catkeys and remove the option

### DIFF
--- a/app/consumers/sdr_consumer.rb
+++ b/app/consumers/sdr_consumer.rb
@@ -56,7 +56,6 @@ class SdrConsumer < Racecar::Consumer
     return true if false_target?
     return true unless true_target?
     return true if record.blank? # No public Cocina
-    return true if @skip_catkey && catkey?
 
     false
   end
@@ -69,11 +68,6 @@ class SdrConsumer < Racecar::Consumer
   # Is the item excluded from release to this target?
   def false_target?
     @target.in? Array(@change['false_targets']).map(&:downcase)
-  end
-
-  # Does the item have a catkey?
-  def catkey?
-    @change['catkey'].present? || record.folio_hrid.present?
   end
 
   # Public cocina record for the item

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -55,7 +55,6 @@ indexer_group: earthworks-dev-indexer
 # released to e.g. searchworks
 purl_fetcher:
   target: earthworks # case-insensitive ("EarthWorks", "Earthworks", etc.)
-  skip_catkey: true # skip indexing if item has a catkey
 
 # Determines the environment that cocina metadata will be fetched from; for
 # stage indexing it should be set to staging PURL

--- a/spec/consumers/sdr_consumer_spec.rb
+++ b/spec/consumers/sdr_consumer_spec.rb
@@ -96,42 +96,6 @@ RSpec.describe SdrConsumer do
       end
     end
 
-    context 'when the record has a catkey' do
-      let(:record) { instance_double(CocinaDisplay::CocinaRecord, folio_hrid: 'a12345') }
-
-      it 'executes a delete' do
-        expect(solr_service).to receive(:delete_by_ids).with(['abc123'])
-        consumer.process_batch([message])
-      end
-    end
-
-    context 'when skip_catkey is false and the record has a catkey' do
-      subject(:consumer) do
-        described_class.new(
-          target: 'earthworks',
-          skip_catkey: false,
-          cocina_service: cocina_service,
-          solr_service: solr_service
-        )
-      end
-
-      let(:record) { instance_double(CocinaDisplay::CocinaRecord, folio_hrid: 'a12345') }
-
-      it 'executes an update' do
-        expect(solr_service).to receive(:update).with(record)
-        consumer.process_batch([message])
-      end
-    end
-
-    context 'when the item is deleted' do
-      let(:message_contents) { { druid: 'druid:abc123', deleted_at: '2024-06-02T00:00:00Z' } }
-
-      it 'executes a delete' do
-        expect(solr_service).to receive(:delete_by_ids).with(['abc123'])
-        consumer.process_batch([message])
-      end
-    end
-
     context 'with multiple deletes' do
       it 'deletes them in one Solr request' do
         messages = %w[abc123 def456 ghi789].map do |druid|


### PR DESCRIPTION
This makes sense for items going to Searchworks, where you
might double-index from FOLIO and SDR, but it'll never happen
for data going to Earthworks because the FOLIO indexer doesn't
target Earthworks.
